### PR TITLE
fix: restore schema format validation in CI

### DIFF
--- a/src/validate/schema.ts
+++ b/src/validate/schema.ts
@@ -6,6 +6,21 @@ export async function validateChordRecords(records: ChordRecord[]): Promise<void
   const schemaRaw = await readFile("chords.schema.json", "utf8");
   const schema = JSON.parse(schemaRaw) as object;
   const ajv = new Ajv2020({ allErrors: true });
+  ajv.addFormat("uri", {
+    type: "string",
+    validate: (value: string) => {
+      try {
+        new URL(value);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+  });
+  ajv.addFormat("date-time", {
+    type: "string",
+    validate: (value: string) => !Number.isNaN(Date.parse(value)),
+  });
   const validate = ajv.compile(schema);
 
   for (const record of records) {


### PR DESCRIPTION
## Summary
- registers runtime format validators for uri and date-time in schema validation
- fixes test/runtime failure where Ajv rejected unknown formats during schema compile

## Why
chords.schema.json uses format constraints for provenance fields. Without registered format validators, validation failed before record checks.

## Validation
- npm run lint
- npm test
- npm run ingest
- npm run build
- npm run validate

Closes #10