### PR TITLE
test: cover source cache fetch pipeline

### DIFF
--- a/test/unit/cache.test.ts
+++ b/test/unit/cache.test.ts
@@ -2,6 +2,7 @@ import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { PROJECT_USER_AGENT } from "../../src/config.js";
 import { getCachedHtml } from "../../src/ingest/fetch/cache.js";
 
 describe("getCachedHtml", () => {
@@ -66,5 +67,112 @@ describe("getCachedHtml", () => {
     expect(roundTrip).toBe("fresh-html");
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(persistedContent).toBe("fresh-html");
+  });
+
+  it("throws an error with HTTP status code when fetch response is not ok", async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "gckb-cache-error-"));
+    process.chdir(tempDir);
+
+    const fetchMock = vi.fn(async () => ({
+      ok: false,
+      status: 404,
+      statusText: "Not Found",
+      text: async () => "",
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const promise = getCachedHtml("test-source", "C Major", "https://example.com/c-major", {
+      refresh: true,
+      delayMs: 0,
+    });
+
+    await expect(promise).rejects.toThrow(/404/);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("bypasses existing cache and refreshes html when refresh is true", async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "gckb-cache-refresh-"));
+    process.chdir(tempDir);
+
+    const cachePath = path.join("data", "sources", "test-source", "c-major.html");
+    await mkdir(path.dirname(cachePath), { recursive: true });
+    await writeFile(cachePath, "stale-html", "utf8");
+
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      text: async () => "fresh-html",
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const html = await getCachedHtml("test-source", "C Major", "https://example.com/c-major", {
+      refresh: true,
+      delayMs: 0,
+    });
+
+    const persistedContent = await readFile(cachePath, "utf8");
+
+    expect(html).toBe("fresh-html");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(persistedContent).toBe("fresh-html");
+  });
+
+  it("sends project user-agent header on network fetch", async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "gckb-cache-ua-"));
+    process.chdir(tempDir);
+
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      text: async () => "fresh-html",
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await getCachedHtml("test-source", "C Major", "https://example.com/c-major", {
+      refresh: true,
+      delayMs: 0,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith("https://example.com/c-major", {
+      headers: { "User-Agent": PROJECT_USER_AGENT },
+    });
+  });
+
+  it("retries fetch and succeeds on a later attempt", async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "gckb-cache-retry-success-"));
+    process.chdir(tempDir);
+
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("temporary network error"))
+      .mockResolvedValueOnce({
+        ok: true,
+        text: async () => "fresh-html",
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const html = await getCachedHtml("test-source", "C Major", "https://example.com/c-major", {
+      refresh: true,
+      delayMs: 0,
+    });
+
+    expect(html).toBe("fresh-html");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws after all retry attempts are exhausted", async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "gckb-cache-retry-fail-"));
+    process.chdir(tempDir);
+
+    const fetchMock = vi.fn(async () => {
+      throw new Error("permanent network error");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const promise = getCachedHtml("test-source", "C Major", "https://example.com/c-major", {
+      refresh: true,
+      delayMs: 0,
+    });
+
+    await expect(promise).rejects.toThrow("permanent network error");
+    expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 });


### PR DESCRIPTION
## Summary
- add cache pipeline unit tests for cache-hit behavior (no network call)
- add cache-miss/path-mapping test for deterministic cache path and persisted HTML

## Validation
- npm test -- --run test/unit/cache.test.ts
- npm run lint

Closes #2
