### PR TITLE
test: expand svg diagram generator sanity checks

### DIFF
--- a/test/unit/svg.test.ts
+++ b/test/unit/svg.test.ts
@@ -13,4 +13,28 @@ describe("generateChordSvg", () => {
     expect(svg).toContain("<circle");
     expect(svg).toContain("aria-label=\"chord:C:maj:v1\"");
   });
+
+  it("is deterministic for the same voicing input", () => {
+    const voicing = {
+      id: "chord:C:7:v1",
+      frets: [null, 3, 2, 3, 1, 0] as Array<number | null>,
+      base_fret: 1,
+    };
+
+    const first = generateChordSvg(voicing);
+    const second = generateChordSvg(voicing);
+
+    expect(first).toBe(second);
+  });
+
+  it("renders muted and open string markers from voicing data", () => {
+    const svg = generateChordSvg({
+      id: "chord:C:maj7:v1",
+      frets: [null, 3, 2, 0, 0, 0],
+      base_fret: 1,
+    });
+
+    expect(svg).toContain(">X<");
+    expect(svg).toContain(">O<");
+  });
 });


### PR DESCRIPTION
## Summary
- expand SVG generator sanity tests
- add deterministic-output assertion and open/muted marker checks

## Validation
- npm test -- --run test/unit/svg.test.ts
- npm run lint

Closes #6
