### PR TITLE
feat: add diagram links in generated chord docs

### DIFF
--- a/src/build/docs/generateDocs.ts
+++ b/src/build/docs/generateDocs.ts
@@ -4,7 +4,13 @@ export function chordMarkdown(chord: ChordRecord): string {
   const aliases = (chord.aliases ?? []).join(", ") || "none";
   const enharmonics = (chord.enharmonic_equivalents ?? []).join(", ") || "none";
   const voicingLines = chord.voicings
-    .map((voicing) => `- ${voicing.id}: frets ${voicing.frets.map((f) => (f === null ? "x" : String(f))).join("/")} (base fret ${voicing.base_fret})`)
+    .slice()
+    .sort((a, b) => a.id.localeCompare(b.id))
+    .map((voicing) => {
+      const frets = voicing.frets.map((fret) => (fret === null ? "x" : String(fret))).join("/");
+      const diagramPath = `../diagrams/${voicing.id.replace(/:/g, "__")}.svg`;
+      return `- ${voicing.id}: frets ${frets} (base fret ${voicing.base_fret}) | diagram: ${diagramPath}`;
+    })
     .join("\n");
 
   const sourceLines = chord.source_refs.map((ref) => `- ${ref.source}: ${ref.url}`).join("\n");

--- a/test/unit/docs.test.ts
+++ b/test/unit/docs.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { chordMarkdown } from "../../src/build/docs/generateDocs.js";
+import type { ChordRecord } from "../../src/types/model.js";
+
+function buildChord(voicingIds: string[]): ChordRecord {
+  return {
+    id: "chord:C:maj",
+    root: "C",
+    quality: "maj",
+    aliases: ["C", "Cmaj"],
+    enharmonic_equivalents: [],
+    formula: ["1", "3", "5"],
+    pitch_classes: ["C", "E", "G"],
+    voicings: voicingIds.map((id, index) => ({
+      id,
+      frets: [null, 3, 2, 0, 1, 0],
+      base_fret: index + 1,
+    })),
+    source_refs: [{ source: "unit", url: "https://example.com/chord" }],
+    notes: { summary: "C major summary." },
+  };
+}
+
+describe("chordMarkdown", () => {
+  it("includes diagram references for each voicing", () => {
+    const markdown = chordMarkdown(buildChord(["chord:C:maj:v2", "chord:C:maj:v1"]));
+
+    expect(markdown).toContain("diagram: ../diagrams/chord__C__maj__v1.svg");
+    expect(markdown).toContain("diagram: ../diagrams/chord__C__maj__v2.svg");
+  });
+
+  it("renders voicings in stable id order", () => {
+    const markdown = chordMarkdown(buildChord(["chord:C:maj:v2", "chord:C:maj:v1"]));
+
+    const v1Index = markdown.indexOf("chord:C:maj:v1");
+    const v2Index = markdown.indexOf("chord:C:maj:v2");
+    expect(v1Index).toBeGreaterThan(-1);
+    expect(v2Index).toBeGreaterThan(-1);
+    expect(v1Index).toBeLessThan(v2Index);
+  });
+});


### PR DESCRIPTION
## Summary
- add diagram links for each generated voicing entry in chord markdown
- enforce stable voicing ordering in docs generator
- add unit tests for diagram references and ordering

## Validation
- npm test -- --run test/unit/docs.test.ts
- npm run lint

Closes #7
