### PR TITLE
test: add comprehensive mvp suite coverage

### DIFF
--- a/test/unit/mvpSuite.test.ts
+++ b/test/unit/mvpSuite.test.ts
@@ -1,0 +1,42 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { writeChordJsonl } from "../../src/build/output/writeJsonl.js";
+import { generateChordSvg } from "../../src/build/svg/generateSvg.js";
+import { ingestNormalizedChords } from "../../src/ingest/pipeline.js";
+import { validateChordRecords } from "../../src/validate/schema.js";
+
+describe("MVP pipeline suite", () => {
+  let tempDir = "";
+
+  afterEach(async () => {
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true });
+      tempDir = "";
+    }
+  });
+
+  it("produces schema-valid chords, JSONL output, and SVG markup", async () => {
+    const chords = await ingestNormalizedChords({ refresh: false, delayMs: 0 });
+    expect(chords.length).toBeGreaterThanOrEqual(4);
+
+    await validateChordRecords(chords);
+
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "gckb-mvp-suite-"));
+    const jsonlPath = path.join(tempDir, "chords.jsonl");
+    await writeChordJsonl(jsonlPath, chords);
+
+    const jsonl = await readFile(jsonlPath, "utf8");
+    const lines = jsonl.split("\n").map((line) => line.trim()).filter(Boolean);
+    expect(lines).toHaveLength(chords.length);
+
+    for (const chord of chords) {
+      for (const voicing of chord.voicings) {
+        const svg = generateChordSvg(voicing);
+        expect(svg).toContain("<svg");
+        expect(svg).toContain(`aria-label=\"${voicing.id}\"`);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add comprehensive MVP suite test that exercises ingest pipeline, JSONL writing, SVG generation, and schema validation

## Validation
- npm test -- --run test/unit/mvpSuite.test.ts
- npm run lint

Closes #9
