### PR TITLE
feat(#61): add min7/dim7/aug/sus quality alias expansion

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,7 @@ export const ROOT_ORDER = [
   "C", "C#", "Db", "D", "D#", "Eb", "E", "F", "F#", "Gb", "G", "G#", "Ab", "A", "A#", "Bb", "B"
 ] as const;
 
-export const QUALITY_ORDER = ["maj", "min", "7", "maj7", "min7", "dim", "aug", "sus2", "sus4"] as const;
+export const QUALITY_ORDER = ["maj", "min", "7", "maj7", "min7", "dim", "dim7", "aug", "sus2", "sus4"] as const;
 
 export const MVP_TARGETS = [
   { source: "guitar-chord-org", slug: "c-major", url: "https://www.guitar-chord.org/c-maj.html" },

--- a/src/ingest/normalize/normalize.ts
+++ b/src/ingest/normalize/normalize.ts
@@ -14,6 +14,8 @@ const QUALITY_MAP: Record<string, ChordQuality> = {
   "Δ7": "maj7",
   M7: "maj7",
   m7: "min7",
+  "-7": "min7",
+  minor7: "min7",
   min7: "min7",
   "7": "7",
   major7: "maj7",
@@ -21,10 +23,20 @@ const QUALITY_MAP: Record<string, ChordQuality> = {
   m7b5: "dim",
   dim: "dim",
   diminished: "dim",
+  "°": "dim",
+  o: "dim",
+  dim7: "dim7",
+  diminished7: "dim7",
+  "°7": "dim7",
+  o7: "dim7",
   aug: "aug",
+  "+": "aug",
   augmented: "aug",
   sus2: "sus2",
-  sus4: "sus4"
+  suspended2: "sus2",
+  sus4: "sus4",
+  suspended4: "sus4",
+  sus: "sus4"
 };
 
 const ENHARMONIC_ROOT: Record<string, string> = {

--- a/src/types/guards.ts
+++ b/src/types/guards.ts
@@ -13,5 +13,5 @@ export function assertCanonicalChordId(value: string): void {
 }
 
 export function isChordQuality(value: string): value is ChordQuality {
-  return ["maj", "min", "7", "maj7", "min7", "dim", "aug", "sus2", "sus4"].includes(value);
+  return ["maj", "min", "7", "maj7", "min7", "dim", "dim7", "aug", "sus2", "sus4"].includes(value);
 }

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -1,4 +1,4 @@
-export type ChordQuality = "maj" | "min" | "7" | "maj7" | "min7" | "dim" | "aug" | "sus2" | "sus4";
+export type ChordQuality = "maj" | "min" | "7" | "maj7" | "min7" | "dim" | "dim7" | "aug" | "sus2" | "sus4";
 
 export interface SourceRef {
   source: string;

--- a/test/unit/modelGuards.test.ts
+++ b/test/unit/modelGuards.test.ts
@@ -25,6 +25,7 @@ describe("assertCanonicalChordId", () => {
 describe("isChordQuality", () => {
   it("matches the allowed quality set", () => {
     expect(isChordQuality("maj")).toBe(true);
+    expect(isChordQuality("dim7")).toBe(true);
     expect(isChordQuality("maj7")).toBe(true);
     expect(isChordQuality("major")).toBe(false);
   });

--- a/test/unit/normalize.test.ts
+++ b/test/unit/normalize.test.ts
@@ -29,19 +29,33 @@ describe("normalizeQuality", () => {
     // min7 variants
     expect(normalizeQuality("m7")).toBe("min7");
     expect(normalizeQuality("min7")).toBe("min7");
+    expect(normalizeQuality("minor7")).toBe("min7");
+    expect(normalizeQuality("-7")).toBe("min7");
 
     // dim variants
     expect(normalizeQuality("dim")).toBe("dim");
     expect(normalizeQuality("diminished")).toBe("dim");
     expect(normalizeQuality("m7b5")).toBe("dim");
+    expect(normalizeQuality("°")).toBe("dim");
+    expect(normalizeQuality("o")).toBe("dim");
+
+    // dim7 variants
+    expect(normalizeQuality("dim7")).toBe("dim7");
+    expect(normalizeQuality("diminished7")).toBe("dim7");
+    expect(normalizeQuality("°7")).toBe("dim7");
+    expect(normalizeQuality("o7")).toBe("dim7");
 
     // aug variants
     expect(normalizeQuality("aug")).toBe("aug");
     expect(normalizeQuality("augmented")).toBe("aug");
+    expect(normalizeQuality("+")).toBe("aug");
 
     // sus variants
     expect(normalizeQuality("sus2")).toBe("sus2");
+    expect(normalizeQuality("suspended2")).toBe("sus2");
     expect(normalizeQuality("sus4")).toBe("sus4");
+    expect(normalizeQuality("suspended4")).toBe("sus4");
+    expect(normalizeQuality("sus")).toBe("sus4");
   });
 
   it("rejects unsupported aliases", () => {


### PR DESCRIPTION
## Summary
- expands canonical quality domain to include `dim7`
- adds normalization aliases for `min7`, `dim`, `dim7`, `aug`, `sus2`, and `sus4` variants
- updates runtime quality guard and quality sort order
- extends unit tests for alias coverage and guard acceptance

## Why
Issue #61 requires broad quality normalization coverage before root/coverage expansion can proceed without unknown-quality failures.

## Validation Run
- npm run lint
- npm test -- test/unit/normalize.test.ts test/unit/modelGuards.test.ts
- npm test
- npm run build
- npm run validate

Closes #61