### PR TITLE
feat: voicing validation guards — fret range and string count

### DIFF
--- a/src/validate/schema.ts
+++ b/src/validate/schema.ts
@@ -7,9 +7,17 @@ function throwVoicingGuard(recordId: string, voicingIndex: number, reason: strin
 }
 
 function validateVoicingGuards(record: ChordRecord): void {
-  const tuningStringCount = record.tuning?.length ?? 6;
+  const tuningStringCount = Array.isArray(record.tuning) ? record.tuning.length : 6;
+
+  if (!Array.isArray(record.voicings)) {
+    return;
+  }
 
   for (const [voicingIndex, voicing] of record.voicings.entries()) {
+    if (!voicing || !Array.isArray(voicing.frets)) {
+      continue;
+    }
+
     if (voicing.frets.length !== tuningStringCount) {
       throwVoicingGuard(record.id, voicingIndex, `expected ${tuningStringCount} strings, received ${voicing.frets.length}`);
     }

--- a/test/unit/schema.test.ts
+++ b/test/unit/schema.test.ts
@@ -207,4 +207,19 @@ describe("validateChordRecords", () => {
 
     await expect(validateChordRecords([invalid])).rejects.toThrow(/all strings are muted/);
   });
+
+  it("defers structurally invalid voicings to Ajv schema errors", async () => {
+    const invalid = {
+      id: "chord:C:maj",
+      root: "C",
+      quality: "maj",
+      aliases: ["C"],
+      formula: ["1", "3", "5"],
+      pitch_classes: ["C", "E", "G"],
+      voicings: null,
+      source_refs: [{ source: "unit", url: "https://example.com" }]
+    } as unknown as ChordRecord;
+
+    await expect(validateChordRecords([invalid])).rejects.toThrow(/Schema validation failed/);
+  });
 });


### PR DESCRIPTION
## Summary
- add explicit voicing guard checks in validation for playable fret range, tuning-aligned string counts, mute consistency, and all-muted rejection
- include chord id + voicing index in guard error messages for actionable debugging
- add unit tests covering out-of-range frets, tuning mismatch, sentinel mute values, and all-muted voicings

## Why
Issue #67 requires hard failures for malformed voicing data so invalid records never reach generated outputs.

## Validation
- npm test -- test/unit/schema.test.ts
- npm run build
- npm run validate
- npm test

Closes #67