### PR TITLE
fix: correct A major source voicings in cached inputs

### DIFF
--- a/data/sources/all-guitar-chords/a-major.html
+++ b/data/sources/all-guitar-chords/a-major.html
@@ -2,7 +2,7 @@
   <div data-formula><code>1</code><code>3</code><code>5</code></div>
   <div data-notes><code>A</code><code>C#</code><code>E</code></div>
   <div data-aliases><code>A</code><code>Amaj</code></div>
-  <div data-voicing data-id="open" data-base-fret="10" data-frets="x-12-11-0-10-0" data-fingers="0-3-2-0-1-0"></div>
-  <div data-voicing data-id="barre" data-base-fret="1" data-frets="12-2-2-1-12-12" data-fingers="1-3-4-2-1-1"></div>
-  <div data-voicing data-id="triad" data-base-fret="1" data-frets="x-x-2-1-12-12" data-fingers="0-0-3-2-1-1"></div>
+  <div data-voicing data-id="variation-1" data-base-fret="1" data-frets="x-0-2-2-2-0" data-fingers="0-0-1-2-3-0"></div>
+  <div data-voicing data-id="variation-2" data-base-fret="2" data-frets="x-x-2-2-2-5" data-fingers="0-0-1-1-1-4"></div>
+  <div data-voicing data-id="variation-3" data-base-fret="5" data-frets="5-7-7-6-5-5" data-fingers="1-3-4-2-1-1"></div>
 </section>

--- a/data/sources/guitar-chord-org/a-major.html
+++ b/data/sources/guitar-chord-org/a-major.html
@@ -2,7 +2,7 @@
   <ul class="formula"><li>1</li><li>3</li><li>5</li></ul>
   <ul class="pitch-classes"><li>A</li><li>C#</li><li>E</li></ul>
   <div class="aliases"><span>A</span><span>Amaj</span></div>
-  <div class="voicing" data-id="open" data-base-fret="10" data-frets="x,12,11,0,10,0" data-fingers="0,3,2,0,1,0"></div>
-  <div class="voicing" data-id="barre" data-base-fret="1" data-frets="12,2,2,1,12,12" data-fingers="1,3,4,2,1,1"></div>
-  <div class="voicing" data-id="triad" data-base-fret="1" data-frets="x,x,2,1,12,12" data-fingers="0,0,3,2,1,1"></div>
+  <div class="voicing" data-id="open" data-base-fret="1" data-frets="x,0,2,2,2,0" data-fingers="0,0,1,2,3,0"></div>
+  <div class="voicing" data-id="barre-5" data-base-fret="5" data-frets="5,7,7,6,5,5" data-fingers="1,3,4,2,1,1"></div>
+  <div class="voicing" data-id="high-voicing" data-base-fret="2" data-frets="x,x,2,2,2,5" data-fingers="0,0,1,1,1,4"></div>
 </article>

--- a/test/unit/pipeline.test.ts
+++ b/test/unit/pipeline.test.ts
@@ -37,6 +37,22 @@ describe("ingestNormalizedChords", () => {
     }
   });
 
+  it("preserves authoritative A major voicing frets and base frets", async () => {
+    const chords = await ingestNormalizedChords({ refresh: false, delayMs: 0 });
+    const aMajor = chords.find((chord) => chord.id === "chord:A:maj");
+
+    expect(aMajor).toBeDefined();
+    expect(aMajor?.voicings.map((voicing) => voicing.frets)).toEqual([
+      [null, 0, 2, 2, 2, 0],
+      [5, 7, 7, 6, 5, 5],
+      [null, null, 2, 2, 2, 5],
+      [null, 0, 2, 2, 2, 0],
+      [null, null, 2, 2, 2, 5],
+      [5, 7, 7, 6, 5, 5],
+    ]);
+    expect(aMajor?.voicings.map((voicing) => voicing.base_fret)).toEqual([1, 5, 2, 1, 2, 5]);
+  });
+
   it("supports dry-run ingestion from a registry-only third source", async () => {
     const originalCwd = process.cwd();
     const tempDir = await mkdtemp(path.join(os.tmpdir(), "gckb-registry-stub-"));


### PR DESCRIPTION
## Summary\n- correct cached A major voicing frets/base-frets in both source cache files under data/sources\n- preserve authoritative variation shapes: x/0/2/2/2/0, x/x/2/2/2/5, 5/7/7/6/5/5\n- add pipeline regression assertion for normalized chord:A:maj voicing frets and base-frets\n\n## Validation\n- npm run lint\n- npm test -- test/unit/pipeline.test.ts test/unit/parser.allGuitarChords.test.ts test/unit/parser.guitarChordOrg.test.ts\n- npm run build\n- npm run validate