### PR TITLE
test: add schema snapshot contract suite for representative chords

### DIFF
--- a/test/unit/__snapshots__/schemaSnapshot.test.ts.snap
+++ b/test/unit/__snapshots__/schemaSnapshot.test.ts.snap
@@ -1,0 +1,840 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`schema snapshot contracts > representative chord records match stored snapshots 1`] = `
+{
+  "aliases": [
+    "C",
+    "Cmaj",
+    "CM",
+    "C major",
+  ],
+  "enharmonic_equivalents": [],
+  "formula": [
+    "1",
+    "3",
+    "5",
+  ],
+  "id": "chord:C:maj",
+  "notes": {
+    "summary": "C maj chord with formula 1-3-5.",
+  },
+  "pitch_classes": [
+    "C",
+    "E",
+    "G",
+  ],
+  "quality": "maj",
+  "root": "C",
+  "source_refs": [
+    {
+      "source": "guitar-chord-org",
+      "url": "https://www.guitar-chord.org/c-maj.html",
+    },
+    {
+      "source": "all-guitar-chords",
+      "url": "https://www.all-guitar-chords.com/chords/index/c/major",
+    },
+  ],
+  "tuning": [
+    "E",
+    "A",
+    "D",
+    "G",
+    "B",
+    "E",
+  ],
+  "voicings": [
+    {
+      "base_fret": 1,
+      "fingers": [
+        0,
+        3,
+        2,
+        0,
+        1,
+        0,
+      ],
+      "frets": [
+        null,
+        3,
+        2,
+        0,
+        1,
+        0,
+      ],
+      "id": "chord:C:maj:v1:guitar-chord-org",
+      "position": "open",
+      "source_refs": [
+        {
+          "source": "guitar-chord-org",
+          "url": "https://www.guitar-chord.org/c-maj.html",
+        },
+      ],
+    },
+    {
+      "base_fret": 3,
+      "fingers": [
+        1,
+        3,
+        4,
+        2,
+        1,
+        1,
+      ],
+      "frets": [
+        3,
+        5,
+        5,
+        4,
+        3,
+        3,
+      ],
+      "id": "chord:C:maj:v2:guitar-chord-org",
+      "position": "unknown",
+      "source_refs": [
+        {
+          "source": "guitar-chord-org",
+          "url": "https://www.guitar-chord.org/c-maj.html",
+        },
+      ],
+    },
+    {
+      "base_fret": 3,
+      "fingers": [
+        0,
+        0,
+        3,
+        2,
+        1,
+        1,
+      ],
+      "frets": [
+        null,
+        null,
+        5,
+        4,
+        3,
+        3,
+      ],
+      "id": "chord:C:maj:v3:guitar-chord-org",
+      "position": "unknown",
+      "source_refs": [
+        {
+          "source": "guitar-chord-org",
+          "url": "https://www.guitar-chord.org/c-maj.html",
+        },
+      ],
+    },
+    {
+      "base_fret": 1,
+      "fingers": [
+        0,
+        3,
+        2,
+        0,
+        1,
+        0,
+      ],
+      "frets": [
+        null,
+        3,
+        2,
+        0,
+        1,
+        0,
+      ],
+      "id": "chord:C:maj:v4:all-guitar-chords",
+      "position": "open",
+      "source_refs": [
+        {
+          "source": "all-guitar-chords",
+          "url": "https://www.all-guitar-chords.com/chords/index/c/major",
+        },
+      ],
+    },
+    {
+      "base_fret": 3,
+      "fingers": [
+        1,
+        3,
+        4,
+        2,
+        1,
+        1,
+      ],
+      "frets": [
+        3,
+        5,
+        5,
+        4,
+        3,
+        3,
+      ],
+      "id": "chord:C:maj:v5:all-guitar-chords",
+      "position": "unknown",
+      "source_refs": [
+        {
+          "source": "all-guitar-chords",
+          "url": "https://www.all-guitar-chords.com/chords/index/c/major",
+        },
+      ],
+    },
+    {
+      "base_fret": 3,
+      "fingers": [
+        0,
+        0,
+        3,
+        2,
+        1,
+        1,
+      ],
+      "frets": [
+        null,
+        null,
+        5,
+        4,
+        3,
+        3,
+      ],
+      "id": "chord:C:maj:v6:all-guitar-chords",
+      "position": "unknown",
+      "source_refs": [
+        {
+          "source": "all-guitar-chords",
+          "url": "https://www.all-guitar-chords.com/chords/index/c/major",
+        },
+      ],
+    },
+  ],
+}
+`;
+
+exports[`schema snapshot contracts > representative chord records match stored snapshots 2`] = `
+{
+  "aliases": [
+    "Cm",
+    "Cmin",
+    "C minor",
+  ],
+  "enharmonic_equivalents": [],
+  "formula": [
+    "1",
+    "b3",
+    "5",
+  ],
+  "id": "chord:C:min",
+  "notes": {
+    "summary": "C min chord with formula 1-b3-5.",
+  },
+  "pitch_classes": [
+    "C",
+    "Eb",
+    "G",
+  ],
+  "quality": "min",
+  "root": "C",
+  "source_refs": [
+    {
+      "source": "guitar-chord-org",
+      "url": "https://www.guitar-chord.org/c-min.html",
+    },
+    {
+      "source": "all-guitar-chords",
+      "url": "https://www.all-guitar-chords.com/chords/index/c/minor",
+    },
+  ],
+  "tuning": [
+    "E",
+    "A",
+    "D",
+    "G",
+    "B",
+    "E",
+  ],
+  "voicings": [
+    {
+      "base_fret": 3,
+      "fingers": [
+        0,
+        1,
+        3,
+        4,
+        2,
+        1,
+      ],
+      "frets": [
+        null,
+        3,
+        5,
+        5,
+        4,
+        3,
+      ],
+      "id": "chord:C:min:v1:guitar-chord-org",
+      "position": "unknown",
+      "source_refs": [
+        {
+          "source": "guitar-chord-org",
+          "url": "https://www.guitar-chord.org/c-min.html",
+        },
+      ],
+    },
+    {
+      "base_fret": 3,
+      "fingers": [
+        1,
+        3,
+        4,
+        1,
+        1,
+        1,
+      ],
+      "frets": [
+        3,
+        5,
+        5,
+        3,
+        3,
+        3,
+      ],
+      "id": "chord:C:min:v2:guitar-chord-org",
+      "position": "barre",
+      "source_refs": [
+        {
+          "source": "guitar-chord-org",
+          "url": "https://www.guitar-chord.org/c-min.html",
+        },
+      ],
+    },
+    {
+      "base_fret": 3,
+      "fingers": [
+        0,
+        0,
+        3,
+        4,
+        2,
+        1,
+      ],
+      "frets": [
+        null,
+        null,
+        5,
+        5,
+        4,
+        3,
+      ],
+      "id": "chord:C:min:v3:guitar-chord-org",
+      "position": "unknown",
+      "source_refs": [
+        {
+          "source": "guitar-chord-org",
+          "url": "https://www.guitar-chord.org/c-min.html",
+        },
+      ],
+    },
+    {
+      "base_fret": 3,
+      "fingers": [
+        0,
+        1,
+        3,
+        4,
+        2,
+        1,
+      ],
+      "frets": [
+        null,
+        3,
+        5,
+        5,
+        4,
+        3,
+      ],
+      "id": "chord:C:min:v4:all-guitar-chords",
+      "position": "unknown",
+      "source_refs": [
+        {
+          "source": "all-guitar-chords",
+          "url": "https://www.all-guitar-chords.com/chords/index/c/minor",
+        },
+      ],
+    },
+    {
+      "base_fret": 3,
+      "fingers": [
+        1,
+        3,
+        4,
+        1,
+        1,
+        1,
+      ],
+      "frets": [
+        3,
+        5,
+        5,
+        3,
+        3,
+        3,
+      ],
+      "id": "chord:C:min:v5:all-guitar-chords",
+      "position": "barre",
+      "source_refs": [
+        {
+          "source": "all-guitar-chords",
+          "url": "https://www.all-guitar-chords.com/chords/index/c/minor",
+        },
+      ],
+    },
+    {
+      "base_fret": 3,
+      "fingers": [
+        0,
+        0,
+        3,
+        4,
+        2,
+        1,
+      ],
+      "frets": [
+        null,
+        null,
+        5,
+        5,
+        4,
+        3,
+      ],
+      "id": "chord:C:min:v6:all-guitar-chords",
+      "position": "unknown",
+      "source_refs": [
+        {
+          "source": "all-guitar-chords",
+          "url": "https://www.all-guitar-chords.com/chords/index/c/minor",
+        },
+      ],
+    },
+  ],
+}
+`;
+
+exports[`schema snapshot contracts > representative chord records match stored snapshots 3`] = `
+{
+  "aliases": [
+    "C7",
+    "Cdom7",
+  ],
+  "enharmonic_equivalents": [],
+  "formula": [
+    "1",
+    "3",
+    "5",
+    "b7",
+  ],
+  "id": "chord:C:7",
+  "notes": {
+    "summary": "C 7 chord with formula 1-3-5-b7.",
+  },
+  "pitch_classes": [
+    "C",
+    "E",
+    "G",
+    "A#",
+  ],
+  "quality": "7",
+  "root": "C",
+  "source_refs": [
+    {
+      "source": "guitar-chord-org",
+      "url": "https://www.guitar-chord.org/c-7.html",
+    },
+    {
+      "source": "all-guitar-chords",
+      "url": "https://www.all-guitar-chords.com/chords/index/c/dominant-7th",
+    },
+  ],
+  "tuning": [
+    "E",
+    "A",
+    "D",
+    "G",
+    "B",
+    "E",
+  ],
+  "voicings": [
+    {
+      "base_fret": 1,
+      "fingers": [
+        0,
+        3,
+        2,
+        4,
+        1,
+        0,
+      ],
+      "frets": [
+        null,
+        3,
+        2,
+        3,
+        1,
+        0,
+      ],
+      "id": "chord:C:7:v1:guitar-chord-org",
+      "position": "open",
+      "source_refs": [
+        {
+          "source": "guitar-chord-org",
+          "url": "https://www.guitar-chord.org/c-7.html",
+        },
+      ],
+    },
+    {
+      "base_fret": 3,
+      "fingers": [
+        1,
+        3,
+        1,
+        2,
+        1,
+        1,
+      ],
+      "frets": [
+        3,
+        5,
+        3,
+        4,
+        3,
+        3,
+      ],
+      "id": "chord:C:7:v2:guitar-chord-org",
+      "position": "barre",
+      "source_refs": [
+        {
+          "source": "guitar-chord-org",
+          "url": "https://www.guitar-chord.org/c-7.html",
+        },
+      ],
+    },
+    {
+      "base_fret": 3,
+      "fingers": [
+        0,
+        0,
+        3,
+        1,
+        1,
+        1,
+      ],
+      "frets": [
+        null,
+        null,
+        5,
+        3,
+        3,
+        3,
+      ],
+      "id": "chord:C:7:v3:guitar-chord-org",
+      "position": "unknown",
+      "source_refs": [
+        {
+          "source": "guitar-chord-org",
+          "url": "https://www.guitar-chord.org/c-7.html",
+        },
+      ],
+    },
+    {
+      "base_fret": 1,
+      "fingers": [
+        0,
+        3,
+        2,
+        4,
+        1,
+        0,
+      ],
+      "frets": [
+        null,
+        3,
+        2,
+        3,
+        1,
+        0,
+      ],
+      "id": "chord:C:7:v4:all-guitar-chords",
+      "position": "open",
+      "source_refs": [
+        {
+          "source": "all-guitar-chords",
+          "url": "https://www.all-guitar-chords.com/chords/index/c/dominant-7th",
+        },
+      ],
+    },
+    {
+      "base_fret": 3,
+      "fingers": [
+        1,
+        3,
+        1,
+        2,
+        1,
+        1,
+      ],
+      "frets": [
+        3,
+        5,
+        3,
+        4,
+        3,
+        3,
+      ],
+      "id": "chord:C:7:v5:all-guitar-chords",
+      "position": "barre",
+      "source_refs": [
+        {
+          "source": "all-guitar-chords",
+          "url": "https://www.all-guitar-chords.com/chords/index/c/dominant-7th",
+        },
+      ],
+    },
+    {
+      "base_fret": 3,
+      "fingers": [
+        0,
+        0,
+        3,
+        1,
+        1,
+        1,
+      ],
+      "frets": [
+        null,
+        null,
+        5,
+        3,
+        3,
+        3,
+      ],
+      "id": "chord:C:7:v6:all-guitar-chords",
+      "position": "unknown",
+      "source_refs": [
+        {
+          "source": "all-guitar-chords",
+          "url": "https://www.all-guitar-chords.com/chords/index/c/dominant-7th",
+        },
+      ],
+    },
+  ],
+}
+`;
+
+exports[`schema snapshot contracts > representative chord records match stored snapshots 4`] = `
+{
+  "aliases": [
+    "Cmaj7",
+    "CM7",
+  ],
+  "enharmonic_equivalents": [],
+  "formula": [
+    "1",
+    "3",
+    "5",
+    "7",
+  ],
+  "id": "chord:C:maj7",
+  "notes": {
+    "summary": "C maj7 chord with formula 1-3-5-7.",
+  },
+  "pitch_classes": [
+    "C",
+    "E",
+    "G",
+    "B",
+  ],
+  "quality": "maj7",
+  "root": "C",
+  "source_refs": [
+    {
+      "source": "guitar-chord-org",
+      "url": "https://www.guitar-chord.org/c-maj7.html",
+    },
+    {
+      "source": "all-guitar-chords",
+      "url": "https://www.all-guitar-chords.com/chords/index/c/major-7th",
+    },
+  ],
+  "tuning": [
+    "E",
+    "A",
+    "D",
+    "G",
+    "B",
+    "E",
+  ],
+  "voicings": [
+    {
+      "base_fret": 2,
+      "fingers": [
+        0,
+        3,
+        2,
+        0,
+        0,
+        0,
+      ],
+      "frets": [
+        null,
+        3,
+        2,
+        0,
+        0,
+        0,
+      ],
+      "id": "chord:C:maj7:v1:guitar-chord-org",
+      "position": "open",
+      "source_refs": [
+        {
+          "source": "guitar-chord-org",
+          "url": "https://www.guitar-chord.org/c-maj7.html",
+        },
+      ],
+    },
+    {
+      "base_fret": 3,
+      "fingers": [
+        1,
+        3,
+        2,
+        4,
+        1,
+        1,
+      ],
+      "frets": [
+        3,
+        5,
+        4,
+        4,
+        3,
+        3,
+      ],
+      "id": "chord:C:maj7:v2:guitar-chord-org",
+      "position": "unknown",
+      "source_refs": [
+        {
+          "source": "guitar-chord-org",
+          "url": "https://www.guitar-chord.org/c-maj7.html",
+        },
+      ],
+    },
+    {
+      "base_fret": 3,
+      "fingers": [
+        0,
+        0,
+        2,
+        1,
+        3,
+        1,
+      ],
+      "frets": [
+        null,
+        null,
+        5,
+        4,
+        5,
+        3,
+      ],
+      "id": "chord:C:maj7:v3:guitar-chord-org",
+      "position": "unknown",
+      "source_refs": [
+        {
+          "source": "guitar-chord-org",
+          "url": "https://www.guitar-chord.org/c-maj7.html",
+        },
+      ],
+    },
+    {
+      "base_fret": 2,
+      "fingers": [
+        0,
+        3,
+        2,
+        0,
+        0,
+        0,
+      ],
+      "frets": [
+        null,
+        3,
+        2,
+        0,
+        0,
+        0,
+      ],
+      "id": "chord:C:maj7:v4:all-guitar-chords",
+      "position": "open",
+      "source_refs": [
+        {
+          "source": "all-guitar-chords",
+          "url": "https://www.all-guitar-chords.com/chords/index/c/major-7th",
+        },
+      ],
+    },
+    {
+      "base_fret": 3,
+      "fingers": [
+        1,
+        3,
+        2,
+        4,
+        1,
+        1,
+      ],
+      "frets": [
+        3,
+        5,
+        4,
+        4,
+        3,
+        3,
+      ],
+      "id": "chord:C:maj7:v5:all-guitar-chords",
+      "position": "unknown",
+      "source_refs": [
+        {
+          "source": "all-guitar-chords",
+          "url": "https://www.all-guitar-chords.com/chords/index/c/major-7th",
+        },
+      ],
+    },
+    {
+      "base_fret": 3,
+      "fingers": [
+        0,
+        0,
+        2,
+        1,
+        3,
+        1,
+      ],
+      "frets": [
+        null,
+        null,
+        5,
+        4,
+        5,
+        3,
+      ],
+      "id": "chord:C:maj7:v6:all-guitar-chords",
+      "position": "unknown",
+      "source_refs": [
+        {
+          "source": "all-guitar-chords",
+          "url": "https://www.all-guitar-chords.com/chords/index/c/major-7th",
+        },
+      ],
+    },
+  ],
+}
+`;

--- a/test/unit/schemaSnapshot.test.ts
+++ b/test/unit/schemaSnapshot.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Schema snapshot contract suite (issue #87)
+ *
+ * Captures the full serialized shape of representative chord records and locks
+ * them in via Vitest snapshots. Any unintentional change to a field name, type,
+ * structural nesting, or sort order will cause a snapshot mismatch and require
+ * an explicit reviewer-approved update.
+ *
+ * Representative set: C maj, C min, C 7, C maj7 — the four MVP chords that
+ * exercise all quality types and provide broad schema-shape coverage.
+ */
+
+import { describe, expect, it } from "vitest";
+import { ingestNormalizedChords } from "../../src/ingest/pipeline.js";
+import { compareChordOrder } from "../../src/utils/sort.js";
+
+const REPRESENTATIVE_IDS = new Set([
+  "chord:C:maj",
+  "chord:C:min",
+  "chord:C:7",
+  "chord:C:maj7",
+]);
+
+describe("schema snapshot contracts", () => {
+  it("representative chord records match stored snapshots", async () => {
+    const all = (await ingestNormalizedChords({ refresh: false, delayMs: 0 }))
+      .slice()
+      .sort(compareChordOrder);
+
+    const representative = all.filter((chord) => REPRESENTATIVE_IDS.has(chord.id));
+
+    expect(representative).toHaveLength(REPRESENTATIVE_IDS.size);
+
+    for (const chord of representative) {
+      // Snapshot each chord separately so diffs are scoped to the affected record
+      expect(chord, `snapshot for ${chord.id}`).toMatchSnapshot();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds `test/unit/schemaSnapshot.test.ts` — a snapshot contract test suite that locks in the full serialized record shape for the four MVP chords (C maj, C min, C 7, C maj7). Closes #87.

## What the test does

1. Runs `ingestNormalizedChords` against the committed source cache
2. Filters to the four representative MVP chord IDs
3. Asserts each record matches its stored Vitest snapshot

If any field is renamed, removed, retyped, or reordered, the relevant snapshot will fail and require an explicit reviewer-approved `vitest run -u` update.

## Snapshot file

`test/unit/__snapshots__/schemaSnapshot.test.ts.snap` — committed alongside the test; 879 lines capturing the full record shape including voicings, source_refs, provenance, aliases, formula, pitch classes.

## Validation

```
npm run lint
npm test
npm run build
npm run validate
```

Lint: passes, 156 tests pass (15 test files). Build: 68 chords. Validate: 68 records.

Closes #87