### PR TITLE
feat: add schema compatibility checker for JSONL evolution

### DIFF
--- a/data/schema-compat-baseline.json
+++ b/data/schema-compat-baseline.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://raw.githubusercontent.com/metal-gogo/guitar-kb/main/chords.schema.json",
+  "description": "Schema compatibility baseline — lists the minimum set of required fields that MUST remain required in chords.schema.json. Any field listed here that is removed from the schema's required[] array is treated as a breaking change by the compatibility checker.",
+  "chord_required": [
+    "id",
+    "root",
+    "quality",
+    "aliases",
+    "formula",
+    "pitch_classes",
+    "voicings",
+    "source_refs"
+  ],
+  "voicing_required": [
+    "id",
+    "frets",
+    "base_fret",
+    "position",
+    "source_refs"
+  ]
+}

--- a/src/cli/validate.ts
+++ b/src/cli/validate.ts
@@ -1,8 +1,13 @@
 import { readFile } from "node:fs/promises";
 import { validateChordRecords } from "../validate/schema.js";
+import { checkSchemaCompatibility } from "../validate/compat.js";
 import type { ChordRecord } from "../types/model.js";
 
 async function main(): Promise<void> {
+  // 1. Schema compatibility check (before record validation so a breaking schema
+  //    change is diagnosed even when the JSONL hasn't been regenerated yet)
+  await checkSchemaCompatibility();
+
   const jsonl = await readFile("data/chords.jsonl", "utf8");
   const records = jsonl
     .split("\n")

--- a/src/validate/compat.ts
+++ b/src/validate/compat.ts
@@ -1,0 +1,85 @@
+import { readFile } from "node:fs/promises";
+
+/**
+ * Thrown when the current `chords.schema.json` drops a required field that is
+ * listed in the committed compatibility baseline.
+ */
+export class SchemaCompatError extends Error {
+  /**
+   * Each entry names the schema section and the field that was removed.
+   * e.g. `{ section: "chord", field: "source_refs" }`
+   */
+  readonly removals: ReadonlyArray<{ section: string; field: string }>;
+
+  constructor(removals: Array<{ section: string; field: string }>) {
+    const lines = removals
+      .map(({ section, field }) => `  [${section}] required field "${field}" was removed`)
+      .join("\n");
+    super(`Schema compatibility check failed — breaking removals detected:\n${lines}`);
+    this.name = "SchemaCompatError";
+    this.removals = removals;
+  }
+}
+
+interface CompatBaseline {
+  chord_required: string[];
+  voicing_required: string[];
+}
+
+interface SchemaShape {
+  required?: string[];
+  properties?: {
+    voicings?: {
+      items?: {
+        required?: string[];
+      };
+    };
+  };
+}
+
+/**
+ * Reads `schemaPath` and `baselinePath`, then verifies that every field listed
+ * as required in the baseline is still required in the current schema.
+ *
+ * - Removing a baseline field from `required[]` → {@link SchemaCompatError}
+ * - Adding new required fields → allowed (stricter schema is non-breaking)
+ * - Removing non-baseline optional fields → not checked here
+ *
+ * @param schemaPath   Path to `chords.schema.json` (default: `"chords.schema.json"`)
+ * @param baselinePath Path to the compat baseline JSON (default: `"data/schema-compat-baseline.json"`)
+ */
+export async function checkSchemaCompatibility(
+  schemaPath = "chords.schema.json",
+  baselinePath = "data/schema-compat-baseline.json",
+): Promise<void> {
+  const [schemaRaw, baselineRaw] = await Promise.all([
+    readFile(schemaPath, "utf8"),
+    readFile(baselinePath, "utf8"),
+  ]);
+
+  const schema = JSON.parse(schemaRaw) as SchemaShape;
+  const baseline = JSON.parse(baselineRaw) as CompatBaseline;
+
+  const schemaChordRequired = new Set(schema.required ?? []);
+  const schemaVoicingRequired = new Set(
+    schema.properties?.voicings?.items?.required ?? [],
+  );
+
+  const removals: Array<{ section: string; field: string }> = [];
+
+  for (const field of baseline.chord_required) {
+    if (!schemaChordRequired.has(field)) {
+      removals.push({ section: "chord", field });
+    }
+  }
+
+  for (const field of baseline.voicing_required) {
+    if (!schemaVoicingRequired.has(field)) {
+      removals.push({ section: "voicing", field });
+    }
+  }
+
+  if (removals.length > 0) {
+    throw new SchemaCompatError(removals);
+  }
+}

--- a/test/unit/compat.test.ts
+++ b/test/unit/compat.test.ts
@@ -1,0 +1,131 @@
+import { writeFile, mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { describe, expect, it, afterEach } from "vitest";
+import { checkSchemaCompatibility, SchemaCompatError } from "../../src/validate/compat.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const BASELINE = JSON.stringify({
+  chord_required: ["id", "root", "quality", "aliases", "formula", "pitch_classes", "voicings", "source_refs"],
+  voicing_required: ["id", "frets", "base_fret", "position", "source_refs"],
+});
+
+function schemaWith(chordRequired: string[], voicingRequired: string[]): string {
+  return JSON.stringify({
+    type: "object",
+    required: chordRequired,
+    properties: {
+      voicings: {
+        type: "array",
+        items: {
+          type: "object",
+          required: voicingRequired,
+        },
+      },
+    },
+  });
+}
+
+const FULL_CHORD_REQUIRED = ["id", "root", "quality", "aliases", "formula", "pitch_classes", "voicings", "source_refs"];
+const FULL_VOICING_REQUIRED = ["id", "frets", "base_fret", "position", "source_refs"];
+
+const tmpDirs: string[] = [];
+
+async function withTmpFiles(schema: string, baseline: string): Promise<[string, string]> {
+  const dir = await mkdtemp(join(tmpdir(), "compat-test-"));
+  tmpDirs.push(dir);
+  const schemaPath = join(dir, "schema.json");
+  const baselinePath = join(dir, "baseline.json");
+  await Promise.all([writeFile(schemaPath, schema), writeFile(baselinePath, baseline)]);
+  return [schemaPath, baselinePath];
+}
+
+afterEach(async () => {
+  for (const dir of tmpDirs.splice(0)) {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("checkSchemaCompatibility", () => {
+  it("passes when schema required fields exactly match the baseline", async () => {
+    const [schemaPath, baselinePath] = await withTmpFiles(
+      schemaWith(FULL_CHORD_REQUIRED, FULL_VOICING_REQUIRED),
+      BASELINE,
+    );
+    await expect(checkSchemaCompatibility(schemaPath, baselinePath)).resolves.toBeUndefined();
+  });
+
+  it("passes when schema has MORE required fields than the baseline (stricter schema)", async () => {
+    const [schemaPath, baselinePath] = await withTmpFiles(
+      schemaWith([...FULL_CHORD_REQUIRED, "extra_field"], FULL_VOICING_REQUIRED),
+      BASELINE,
+    );
+    await expect(checkSchemaCompatibility(schemaPath, baselinePath)).resolves.toBeUndefined();
+  });
+
+  it("throws SchemaCompatError when a baseline chord field is removed from schema required[]", async () => {
+    const reduced = FULL_CHORD_REQUIRED.filter((f) => f !== "source_refs");
+    const [schemaPath, baselinePath] = await withTmpFiles(
+      schemaWith(reduced, FULL_VOICING_REQUIRED),
+      BASELINE,
+    );
+    await expect(checkSchemaCompatibility(schemaPath, baselinePath)).rejects.toThrow(SchemaCompatError);
+  });
+
+  it("throws SchemaCompatError when a baseline voicing field is removed from schema required[]", async () => {
+    const reduced = FULL_VOICING_REQUIRED.filter((f) => f !== "frets");
+    const [schemaPath, baselinePath] = await withTmpFiles(
+      schemaWith(FULL_CHORD_REQUIRED, reduced),
+      BASELINE,
+    );
+    await expect(checkSchemaCompatibility(schemaPath, baselinePath)).rejects.toThrow(SchemaCompatError);
+  });
+
+  it("error message names the section and field for each breaking removal", async () => {
+    const reducedChord = FULL_CHORD_REQUIRED.filter((f) => f !== "aliases");
+    const reducedVoicing = FULL_VOICING_REQUIRED.filter((f) => f !== "position");
+    const [schemaPath, baselinePath] = await withTmpFiles(
+      schemaWith(reducedChord, reducedVoicing),
+      BASELINE,
+    );
+    let err: SchemaCompatError | undefined;
+    try {
+      await checkSchemaCompatibility(schemaPath, baselinePath);
+    } catch (e) {
+      err = e as SchemaCompatError;
+    }
+    expect(err).toBeInstanceOf(SchemaCompatError);
+    expect(err?.message).toContain("[chord]");
+    expect(err?.message).toContain("aliases");
+    expect(err?.message).toContain("[voicing]");
+    expect(err?.message).toContain("position");
+  });
+
+  it("structured removals property lists every broken field with its section", async () => {
+    const reduced = FULL_CHORD_REQUIRED.filter((f) => f !== "formula");
+    const [schemaPath, baselinePath] = await withTmpFiles(
+      schemaWith(reduced, FULL_VOICING_REQUIRED),
+      BASELINE,
+    );
+    let err: SchemaCompatError | undefined;
+    try {
+      await checkSchemaCompatibility(schemaPath, baselinePath);
+    } catch (e) {
+      err = e as SchemaCompatError;
+    }
+    expect(err?.removals).toHaveLength(1);
+    expect(err?.removals[0]).toEqual({ section: "chord", field: "formula" });
+  });
+
+  it("passes against the actual chords.schema.json and live baseline", async () => {
+    // Integration: real schema and real baseline should always be compatible
+    await expect(checkSchemaCompatibility()).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

Adds a schema compatibility check that prevents accidental removal of required fields from `chords.schema.json` (issue #107).

## Changes

### New: `data/schema-compat-baseline.json`
Committed baseline contract listing the minimum required fields for chord records and voicings. Removing a field from this baseline signals an intentional breaking change.

### New: `src/validate/compat.ts`
- `SchemaCompatError` — structured error with typed `.removals` property
- `checkSchemaCompatibility(schemaPath?, baselinePath?)` — diffs schema's `required[]` against the baseline; throws on any removal; allows additions (stricter is non-breaking)

### Updated: `src/cli/validate.ts`
- `checkSchemaCompatibility()` is now the first step in `npm run validate`, before JSONL record validation

### New: `test/unit/compat.test.ts`
7 tests: exact match, stricter schema, chord field removal, voicing field removal, multi-field error message format, `.removals` structured property, live integration against real schema + baseline.

## Validation

```
npm run lint     # passes
npm test         # 164 tests, all pass
npm run validate # Validated 68 chord records (compat check runs first)
```

Closes #107