### PR TITLE
chore: planning prompt refresh for next seeding cycle (#101)

### DIFF
--- a/planning/prompts/planning-stage-issue-seeding.md
+++ b/planning/prompts/planning-stage-issue-seeding.md
@@ -2,6 +2,12 @@
 
 Use this prompt to generate the next roadmap wave (one parent planning issue plus 10–20 child execution issues) with consistent triage.
 
+> **Revision history**
+> - v1 — initial seeding wave (MVP foundation)
+> - v2 (current) — lessons from P0/P1 completion wave; adds label policy,
+>   dependency notation, execution ordering, `status/blocked` handling, and
+>   Copilot review integration guidance
+
 ---
 
 ```
@@ -29,41 +35,135 @@ Required outputs:
    - exactly one `priority/*`
    - exactly one `area/*`
 
-Priority ordering rule:
-- Use P0 only for immediate correctness/security blockers.
-- Use P1 for foundational reliability and determinism work.
-- Use P2 for medium-priority feature and quality improvements.
-- Use P3 for lower-priority polish.
+------------------------------------------------------------
+LABEL POLICY
+------------------------------------------------------------
+
+Status labels follow a strict lifecycle:
+
+  status/backlog → status/in-progress → (closed)
+                         ↓ (if blocked)
+                   status/blocked
+
+Rules:
+- Every new issue MUST start with `status/backlog`.
+- When work begins, swap `status/backlog` for `status/in-progress`.
+- If work is blocked (e.g., waiting on another issue, external dependency,
+  or credentials), swap `status/in-progress` for `status/blocked` and
+  leave a comment on the issue describing the blocker.
+- When the blocker resolves, swap back to `status/in-progress`.
+- Closed issues must have no `status/*` label (GitHub removes them on close).
+- Never leave a label change silent — always leave a comment when changing
+  from `backlog` to `in-progress`, or adding `status/blocked`.
+
+Priority labels:
+- `priority/p0` — immediate correctness or security blocker.
+- `priority/p1` — foundational reliability/determinism work.
+- `priority/p2` — medium-priority feature and quality improvement.
+- `priority/p3` — lower-priority polish.
 - Treat direct user feedback as `priority/p0` by default unless the user
-   explicitly states a different priority.
+  explicitly states a different priority.
 
-Area mapping rule:
-- ingest/parsers/cache: `area/ingest`
-- normalization/canonical IDs: `area/normalize`
-- schema/model contracts: `area/data-model`
-- docs/svg/site structure: `area/docs-svg`
-- tests/CI/release gates: `area/ci-test`
+Area labels — choose exactly one:
+- `area/ingest`      — ingest, parsers, caching, fetch pipeline
+- `area/normalize`   — normalization, canonical IDs, enharmonics
+- `area/data-model`  — schema, type models, model contracts
+- `area/docs-svg`    — docs generation, SVG diagrams, site structure
+- `area/ci-test`     — tests, CI pipelines, release gates, tooling
 
-Issue-writing rules:
+------------------------------------------------------------
+DEPENDENCY NOTATION
+------------------------------------------------------------
+
+When one issue must precede another, write explicit dependency lines in the
+issue body:
+
+  **Depends on**: #<N> — <short reason>
+
+Or for soft ordering preference (not a hard block):
+
+  **Suggested after**: #<N> — <short reason>
+
+Rules:
+- Only use "Depends on" for genuine hard blockers (the PR cannot be
+  meaningfully implemented or tested without the upstream issue being merged).
+- List one dependency per line.
+- Use ascending issue numbers in dependency chains where possible to keep
+  the execution graph acyclic.
+- When generating a wave with interdependencies, sort proposed issues so that
+  upstream items have lower numbers.
+
+------------------------------------------------------------
+EXECUTION ORDERING GUIDANCE
+------------------------------------------------------------
+
+Autonomous execution will process issues in this order:
+
+  P0 → P1 → P2 → P3 (absolute priority)
+  Within same priority: oldest created_at, then ascending issue number
+
+When designing a wave:
+- Seed foundational/blocking issues at lower numbers (they will execute first).
+- Seed dependent issues at higher numbers (they execute after blockers).
+- Do NOT artificially inflate a priority just to force ordering — use
+  dependency notation instead.
+- Issues that can be implemented in parallel (no ordering dependency) should
+  use the same priority and similar creation date.
+
+------------------------------------------------------------
+COPILOT REVIEW INTEGRATION
+------------------------------------------------------------
+
+Issues that change the following require Copilot review awareness:
+- Source parsers or the parser interface
+- Normalization / canonical ID logic
+- Schema fields (`chords.schema.json`)
+- CI workflow files (`.github/workflows/`)
+- Any output consumed by the `validate` script
+
+For these, add to the Acceptance Criteria:
+
+  - [ ] All Copilot inline review comments addressed
+  - [ ] `require-copilot-review` CI check green before merge
+
+For docs-only or chore issues with no runtime impact, this can be omitted
+but must still pass CI.
+
+------------------------------------------------------------
+ISSUE-WRITING RULES
+------------------------------------------------------------
+
 - Keep each issue independently executable in one PR when possible.
 - Avoid mega-issues; split by vertical slice and measurable acceptance criteria.
 - Include determinism and schema validity expectations where applicable.
-- Require provenance preservation where ingestion/model changes are involved.
+- Require provenance preservation (`source_refs`) where ingestion/model changes
+  are involved.
+- Every Acceptance Criteria section must include:
+    - At least one local validation command (`npm run ...`)
+    - Expected outcome (e.g., "exits 0", "all tests pass", "no schema errors")
+- For new CLI commands or new npm scripts, include a README update requirement.
 
-Autonomy rules for generated plan:
-- Assume autonomous execution will process issues by priority (P0→P1→P2→P3), then oldest-to-newest (`created_at`) with issue number as tie-breaker.
-- Include dependencies explicitly when sequencing matters.
-- Prefer p1 tasks first only within the P1 tier; never override P0-first ordering.
-- Insert a feedback review cycle after initial issue seeding before locking final priorities.
+------------------------------------------------------------
+DO NOT
+------------------------------------------------------------
 
-Do not:
-- leave any created issue without triage labels
-- generate tasks with vague acceptance criteria
-- include direct commits to main
+- Leave any created issue without all three triage labels
+  (`status/backlog`, `priority/*`, `area/*`)
+- Generate tasks with vague acceptance criteria ("works correctly", "looks good")
+- Include direct commits to main
+- Create issues for work already implemented and tested in main
+- Use `status/blocked` on a newly seeded issue (it should start as `status/backlog`)
 
-Feedback prompt template (use after initial seeding):
+------------------------------------------------------------
+FEEDBACK PROMPT TEMPLATE
+------------------------------------------------------------
+
+Use after initial seeding before locking final priorities:
+
 - "What tasks are not working as expected so far?"
 - "Which issues should be adjusted (scope, acceptance criteria, priority, or area label)?"
 - "Do you want any tasks split into smaller issues or merged to reduce overhead?"
 - "What should be the top 3 priorities for the next execution cycle?"
+- "Are there any dependency chains I should reconsider?"
+- "Are there issues that should be marked `status/blocked` on a known upstream dependency?"
 ```


### PR DESCRIPTION
## Summary

Closes #101.

Refreshes `planning/prompts/planning-stage-issue-seeding.md` (now v2) with lessons learned from the P0/P1 completion wave.

## Changes

- **Revision history block** added to track future prompt version changes
- **Label policy** section: full `status/*` lifecycle diagram with transition rules and blocked-state handling
- **Dependency notation** section: explicit syntax for hard (`Depends on`) vs soft (`Suggested after`) ordering, rules for acyclic dependency graphs
- **Execution ordering guidance**: how autonomous agents process issues by priority then by `created_at`/number, and how to sequence a new wave to align with that
- **Copilot review integration**: which change categories require copilot-review awareness in Acceptance Criteria
- **Issue-writing rules** expanded: mandatory local command + expected outcome in every AC; README update requirement for new CLI scripts
- **Feedback prompt** expanded: adds dependency chain review and `status/blocked` identification questions
- **DO NOT** section consolidated and tightened

## Local Validation Evidence

```
npm run lint   # clean (tsc --noEmit → exit 0)
npm test       # 244 tests, 22 files — all pass
```

Documentation only — no source code changed.