### PR TITLE
feat: root-quality gap triage labels in report (#121)

### DIFF
--- a/src/cli/validate.ts
+++ b/src/cli/validate.ts
@@ -34,8 +34,16 @@ async function main(): Promise<void> {
   );
   if (coverage.missingCanonicalIds.length > 0) {
     process.stdout.write(`Missing root-quality canonical IDs (${coverage.missingCanonicalIds.length}):\n`);
+    process.stdout.write(
+      `Missing severity counts: critical=${coverage.missingSeverityCounts.critical} high=${coverage.missingSeverityCounts.high} medium=${coverage.missingSeverityCounts.medium} low=${coverage.missingSeverityCounts.low}\n`,
+    );
     for (const id of coverage.missingCanonicalIds) {
       process.stdout.write(`MISSING ${id}\n`);
+    }
+    for (const missing of coverage.missingTagged) {
+      process.stdout.write(
+        `MISSING_TAG ${missing.canonicalId} severity=${missing.severity} tags=${missing.tags.join(",")}\n`,
+      );
     }
   } else {
     process.stdout.write("Missing root-quality canonical IDs (0): none\n");


### PR DESCRIPTION
## Summary
Closes #121.

Enhances root-quality coverage reporting with deterministic severity tags and per-severity counts for missing matrix entries, while preserving existing coverage summary output.

## What Changed
- Extended coverage model in `src/validate/coverage.ts`:
  - added `CoverageGapSeverity` (`critical|high|medium|low`)
  - added `missingTagged` machine-readable entries
  - added `missingSeverityCounts`
  - deterministic severity mapping by quality:
    - `critical`: `maj`, `min`, `7`, `maj7`
    - `high`: `min7`
    - `medium`: `dim`, `dim7`, `aug`
    - `low`: `sus2`, `sus4`
- Updated `src/cli/validate.ts` output:
  - added severity count summary line
  - added deterministic `MISSING_TAG ... severity=... tags=...` lines for CI parsing
  - retained existing `MISSING ...` lines for compatibility
- Added/updated tests in `test/unit/coverage.test.ts`:
  - severity bucket classification behavior
  - deterministic tagged output ordering
  - severity count assertions

## Validation
```bash
npm run validate
npm test -- test/unit/mvpSuite.test.ts
npm run lint
npm test
npm run build
npm run validate
npm run check-links
```

## Notes
- Existing coverage summary and missing-ID lines remain unchanged.
- New tagged lines are additive and deterministic for CI consumers.
