### PR TITLE
chore(planning): seed wave d issue backlog

### DIFF
--- a/planning/issues/036-planning-wave-d-coverage-completion-and-quality-gates.md
+++ b/planning/issues/036-planning-wave-d-coverage-completion-and-quality-gates.md
@@ -1,0 +1,108 @@
+# Issue: Planning Wave D — Coverage Completion and Quality Gates
+
+## Triage Labels
+
+- `status/backlog`
+- `priority/p0`
+- `area/ci-test`
+
+## Summary
+
+Seed the next execution wave to close the current root-quality coverage gap,
+complete all defined qualities (not just major-family coverage), enforce full
+voicing completeness, and generate a navigable website from build outputs.
+
+This wave includes 15 implementation-ready child issues (`037`–`051`) with
+explicit ordering and dependencies.
+
+## Planning Scope
+
+- Expand ingest/normalize support from core qualities (`maj`, `min`, `7`, `maj7`)
+  to full defined quality coverage already modeled in validation (`min7`, `dim`,
+  `dim7`, `aug`, `sus2`, `sus4`) across all configured roots.
+- Prioritize full defined-quality matrix completion before lower-priority polish.
+- Ensure all statically available voicings are ingested per chord across
+  all defined qualities.
+- Keep deterministic build outputs and schema/provenance guarantees unchanged.
+- Move key diagnostics into CI signals:
+  - root-quality coverage policy
+  - cache freshness/cache integrity
+  - parser confidence reporting
+- Improve docs discoverability with a generated coverage dashboard and a
+  navigable generated website.
+
+## Linked References
+
+- ADR-0001: `planning/decisions/0001-canonical-id-and-enharmonics.md`
+- ADR-0004: `planning/decisions/0004-artifact-versioning-policy.md`
+- ADR-0006: `planning/decisions/0006-next-planning-wave-and-triage.md`
+- Seeding prompt: `planning/prompts/planning-stage-issue-seeding.md`
+
+## Child Issues
+
+- [037](./037-coverage-matrix-contract-and-threshold-policy.md) — coverage matrix contract and threshold policy
+- [038](./038-extended-quality-target-expansion.md) — extended-quality ingest target expansion
+- [039](./039-source-capability-map-and-unsupported-target-reporting.md) — source capability map and unsupported-target reporting
+- [040](./040-extended-quality-parser-fixtures.md) — extended-quality parser fixtures
+- [041](./041-parser-extended-quality-extraction.md) — parser extraction for extended qualities
+- [042](./042-normalization-quality-alias-hardening.md) — normalization quality alias hardening
+- [043](./043-cli-filter-engine-generalization.md) — CLI/build filter generalization beyond MVP-only target assumptions
+- [044](./044-coverage-gate-enforcement-in-validate-and-ci.md) — coverage gate enforcement in validate + CI
+- [045](./045-ci-freshness-and-cache-audit-automation.md) — scheduled freshness/cache audit automation
+- [046](./046-docs-coverage-dashboard-generation.md) — generated docs coverage dashboard
+- [047](./047-parser-confidence-reporting-pipeline.md) — parser confidence reporting pipeline
+- [048](./048-fixture-cache-parity-checks.md) — fixture/cache parity checks
+- [049](./049-full-voicing-coverage-across-defined-quality-matrix.md) — full voicing coverage across defined-quality matrix
+- [050](./050-generated-website-and-navigation.md) — generated website and navigation
+- [051](./051-website-publishing-pipeline.md) — website publishing pipeline
+
+## Execution Order
+
+1. `037` → `038` → `039` → `040` → `041` → `042` → `049`
+2. `044` (after `042` and `049`)
+3. `043` and `048` (parallel-safe after `038`)
+4. `045` and `047` (parallel-safe after parser/ingest baselines are stable)
+5. `046` (after `044`)
+6. `050` (after `046` and `049`)
+7. `051` (after `050`)
+
+## Feedback Checkpoint (Mandatory Before Locking Priorities)
+
+Please answer these before active execution starts:
+
+- What tasks are not working as expected so far?
+- Which issues should be adjusted (scope, acceptance criteria, priority, or area label)?
+- Do you want any tasks split into smaller issues or merged to reduce overhead?
+- What should be the top 3 priorities for the next execution cycle?
+- Are there any dependency chains I should reconsider?
+- Are there issues that should be marked `status/blocked` on a known upstream dependency?
+
+## Feedback Iteration Plan
+
+After feedback:
+
+1. Re-triage impacted issues (`priority/*`, `area/*`, `status/*`) without leaving unlabeled gaps.
+2. Split/merge tasks where requested while preserving one-PR-per-issue execution.
+3. Add or adjust `Depends on` / `Suggested after` lines to keep ordering acyclic.
+4. Create follow-up issue drafts for newly surfaced work with full triage labels.
+
+## Acceptance Criteria
+
+- 15 child issues exist and each has `Summary`, `Scope`, `Acceptance Criteria`,
+  and `Validation Steps`.
+- Every seeded issue includes exactly:
+  - one `status/*` label (`status/backlog` on creation),
+  - one `priority/*` label,
+  - one `area/*` label.
+- Dependency notation is explicit where hard/soft ordering is required.
+
+## Validation Steps
+
+```bash
+ls planning/issues/03{6,7,8,9}-*.md planning/issues/04{0,1,2,3,4,5,6,7,8,9}-*.md planning/issues/05{0,1}-*.md
+rg -n "status/backlog|priority/p[0-3]|area/" planning/issues/03*.md planning/issues/04*.md planning/issues/05*.md
+```
+
+Expected outcome:
+- Both commands exit `0`.
+- 16 files (`036` parent + `037`–`051` children) are present with triage labels.

--- a/planning/issues/037-coverage-matrix-contract-and-threshold-policy.md
+++ b/planning/issues/037-coverage-matrix-contract-and-threshold-policy.md
@@ -1,0 +1,46 @@
+# Issue: Coverage Matrix Contract and Threshold Policy
+
+## Triage Labels
+
+- `status/backlog`
+- `priority/p0`
+- `area/data-model`
+
+## Summary
+
+Define and implement a stable root-quality coverage contract so `validate` can
+enforce full defined-quality matrix coverage against an explicit matrix
+definition rather than implicit defaults.
+
+## Scope
+
+- Add a versioned coverage matrix contract in code (roots, qualities, severity
+  mapping, and deterministic sort order).
+- Mark all currently defined qualities in `QUALITY_ORDER` as in-scope matrix
+  members for completeness accounting.
+- Emit matrix metadata in `npm run validate` output (`matrix_version`,
+  `expected_roots`, `expected_qualities`).
+- Add tests for contract stability and ordering.
+- Document the policy in `README.md` under validation/coverage behavior.
+
+## Acceptance Criteria
+
+- [ ] Coverage report includes explicit matrix metadata and stable ordering.
+- [ ] Contract tests fail on accidental matrix drift.
+- [ ] Matrix definition includes all defined qualities (`maj`, `min`, `7`,
+  `maj7`, `min7`, `dim`, `dim7`, `aug`, `sus2`, `sus4`).
+- [ ] `npm run validate` exits `0` and prints matrix metadata on a healthy build.
+- [ ] `npm test -- test/unit/coverage.test.ts` exits `0` and covers the new contract behavior.
+- [ ] All Copilot inline review comments addressed
+- [ ] `require-copilot-review` CI check green before merge
+
+## Validation Steps
+
+```bash
+npm test -- test/unit/coverage.test.ts
+npm run validate
+```
+
+Expected outcome:
+- Both commands exit `0`.
+- `validate` output includes deterministic matrix metadata fields.

--- a/planning/issues/038-extended-quality-target-expansion.md
+++ b/planning/issues/038-extended-quality-target-expansion.md
@@ -1,0 +1,45 @@
+# Issue: Extended-Quality Target Expansion
+
+## Triage Labels
+
+- `status/backlog`
+- `priority/p0`
+- `area/ingest`
+
+**Depends on**: #037 — align target generation with the explicit coverage matrix
+
+## Summary
+
+Expand ingest targets beyond core qualities so the pipeline can fetch and parse
+the full defined quality set (`maj`, `min`, `7`, `maj7`, `min7`, `dim`,
+`dim7`, `aug`, `sus2`, `sus4`) across all configured roots.
+
+## Scope
+
+- Extend target generation in `src/config.ts` with deterministic mappings for
+  extended qualities per source.
+- Ensure no defined quality in the matrix is omitted from target generation.
+- Preserve canonical ID format (`chord:<ROOT>:<QUALITY>`) and deterministic
+  target ordering.
+- Add unit tests for target count, URL formatting, and ordering stability.
+- Keep core-quality behavior unchanged for existing targets.
+
+## Acceptance Criteria
+
+- [ ] Ingest target generation includes all defined qualities with correct URLs/slugs.
+- [ ] Existing core targets remain byte-stable (no regressions in current URLs).
+- [ ] `npm run ingest -- --dry-run` lists extended-quality targets deterministically.
+- [ ] `npm test -- test/unit/pipeline.test.ts test/unit/sourceRegistry.test.ts` exits `0`.
+- [ ] All Copilot inline review comments addressed
+- [ ] `require-copilot-review` CI check green before merge
+
+## Validation Steps
+
+```bash
+npm run ingest -- --dry-run
+npm test -- test/unit/pipeline.test.ts test/unit/sourceRegistry.test.ts
+```
+
+Expected outcome:
+- Both commands exit `0`.
+- Dry-run output includes extended-quality chord IDs in deterministic order.

--- a/planning/issues/039-source-capability-map-and-unsupported-target-reporting.md
+++ b/planning/issues/039-source-capability-map-and-unsupported-target-reporting.md
@@ -1,0 +1,50 @@
+# Issue: Source Capability Map and Unsupported-Target Reporting
+
+## Triage Labels
+
+- `status/backlog`
+- `priority/p0`
+- `area/ingest`
+
+**Depends on**: #038 — extended targets require explicit per-source support metadata
+
+## Summary
+
+Introduce per-source capability declarations so ingest can distinguish between
+"missing due to parser/data bug" and "not supported by source", while treating
+defined-quality coverage gaps as explicit backlog failures rather than silent skips.
+
+## Scope
+
+- Add source capability metadata (supported qualities/roots) to the source registry.
+- Update ingest dry-run and runtime logs to report unsupported targets
+  with deterministic reason codes and gap counts.
+- Add strict mode behavior that fails ingest when required defined-quality
+  matrix targets are unresolved.
+- Support an explicit, documented temporary allowlist for known upstream gaps.
+- Add tests for capability filtering and stable skip reporting.
+
+## Acceptance Criteria
+
+- [ ] Each source entry declares support metadata used during target selection.
+- [ ] Ingest reports unsupported targets as `SKIP_UNSUPPORTED` with deterministic ordering.
+- [ ] In strict mode, unresolved defined-quality gaps fail with a clear summary.
+- [ ] Any temporary allowlisted gap is surfaced in output and remains deterministic.
+- [ ] `npm run ingest -- --dry-run --source guitar-chord-org` exits `0` and includes skip diagnostics.
+- [ ] `env INGEST_STRICT_CAPABILITIES=1 npm run ingest -- --dry-run` exits non-zero when unresolved required gaps remain.
+- [ ] `npm test -- test/unit/pipeline.test.ts` exits `0`.
+- [ ] All Copilot inline review comments addressed
+- [ ] `require-copilot-review` CI check green before merge
+
+## Validation Steps
+
+```bash
+npm run ingest -- --dry-run --source guitar-chord-org
+env INGEST_STRICT_CAPABILITIES=1 npm run ingest -- --dry-run
+npm test -- test/unit/pipeline.test.ts
+```
+
+Expected outcome:
+- First and third commands exit `0`.
+- Strict-mode command exits non-zero if required matrix gaps exist.
+- Dry-run includes processed/skipped counts, unsupported-target reason lines, and gap summary.

--- a/planning/issues/040-extended-quality-parser-fixtures.md
+++ b/planning/issues/040-extended-quality-parser-fixtures.md
@@ -1,0 +1,45 @@
+# Issue: Extended-Quality Parser Fixtures
+
+## Triage Labels
+
+- `status/backlog`
+- `priority/p0`
+- `area/ingest`
+
+**Depends on**: #038 — fixture set must match expanded target/quality matrix
+**Suggested after**: #039 — align fixtures to capability reporting semantics
+
+## Summary
+
+Add minimal parser fixtures for extended-quality pages and targeted failure
+cases so parser behavior is testable offline for the expanded chord set.
+
+## Scope
+
+- Add original (non-copied) minimal HTML fixtures for new quality cases in:
+  - `test/fixtures/sources/guitar-chord-org/`
+  - `test/fixtures/sources/all-guitar-chords/`
+- Ensure fixture coverage includes every defined non-core quality (`min7`,
+  `dim`, `dim7`, `aug`, `sus2`, `sus4`) per source.
+- Add edge fixtures for malformed/partial extended-quality markup.
+- Add representative high-variation fixtures to validate full voicing capture.
+- Update parser tests to consume the new fixtures.
+- Update `docs/contributing/parser-fixtures.md` fixture inventory.
+
+## Acceptance Criteria
+
+- [ ] Fixture set includes at least one happy-path sample per new quality per source.
+- [ ] Fixture set includes explicit edge/failure fixtures for extended qualities.
+- [ ] Fixture set includes at least one multi-voicing fixture per source to verify non-truncated parsing.
+- [ ] Parser unit tests reference every newly added fixture.
+- [ ] `npm test -- test/unit/parser.guitarChordOrg.test.ts test/unit/parser.allGuitarChords.test.ts` exits `0`.
+
+## Validation Steps
+
+```bash
+npm test -- test/unit/parser.guitarChordOrg.test.ts test/unit/parser.allGuitarChords.test.ts
+```
+
+Expected outcome:
+- Command exits `0`.
+- New fixtures are covered by parser tests with deterministic assertions.

--- a/planning/issues/041-parser-extended-quality-extraction.md
+++ b/planning/issues/041-parser-extended-quality-extraction.md
@@ -1,0 +1,46 @@
+# Issue: Parser Extended-Quality Extraction
+
+## Triage Labels
+
+- `status/backlog`
+- `priority/p0`
+- `area/ingest`
+
+**Depends on**: #039 — capability metadata defines expected parser coverage
+**Depends on**: #040 — fixtures provide deterministic parser test inputs
+
+## Summary
+
+Upgrade both source parsers to reliably extract extended-quality chord records
+and voicings while preserving deterministic output and provenance fields.
+
+## Scope
+
+- Extend `parseGuitarChordOrg` and `parseAllGuitarChords` quality extraction for
+  `min7`, `dim`, `dim7`, `aug`, `sus2`, and `sus4`.
+- Keep voicing extraction complete and stable for each parsed chord page with
+  no quality-specific truncation.
+- Improve parser error context with source id + target URL + quality token.
+- Preserve `source_refs` on every emitted chord and voicing.
+
+## Acceptance Criteria
+
+- [ ] Both parsers emit normalized-ready records for supported extended-quality targets.
+- [ ] Parser output covers all defined qualities present in configured sources.
+- [ ] Parser errors include structured context for debugging failures.
+- [ ] No regressions on existing core-quality parser tests.
+- [ ] `npm test -- test/unit/parser.guitarChordOrg.test.ts test/unit/parser.allGuitarChords.test.ts test/unit/parser.invariants.test.ts` exits `0`.
+- [ ] `npm run ingest -- --dry-run --chord chord:C:min7` exits `0`.
+- [ ] All Copilot inline review comments addressed
+- [ ] `require-copilot-review` CI check green before merge
+
+## Validation Steps
+
+```bash
+npm test -- test/unit/parser.guitarChordOrg.test.ts test/unit/parser.allGuitarChords.test.ts test/unit/parser.invariants.test.ts
+npm run ingest -- --dry-run --chord chord:C:min7
+```
+
+Expected outcome:
+- Both commands exit `0`.
+- Dry-run no longer treats supported extended-quality targets as parser failures.

--- a/planning/issues/042-normalization-quality-alias-hardening.md
+++ b/planning/issues/042-normalization-quality-alias-hardening.md
@@ -1,0 +1,43 @@
+# Issue: Normalization Quality Alias Hardening
+
+## Triage Labels
+
+- `status/backlog`
+- `priority/p0`
+- `area/normalize`
+
+**Depends on**: #041 — parser output must carry extended-quality symbols to normalize
+
+## Summary
+
+Harden normalization so extended-quality aliases and symbols map consistently to
+canonical quality enums and stable canonical IDs.
+
+## Scope
+
+- Extend quality alias/symbol mapping in normalization for extended qualities.
+- Preserve canonical ID stability (`chord:<ROOT>:<QUALITY>`) across alias inputs.
+- Retain useful source aliases in `aliases[]` without losing canonical mapping.
+- Add normalization and enharmonic tests for new aliases/symbols.
+
+## Acceptance Criteria
+
+- [ ] Extended-quality aliases normalize to the expected canonical `quality` values.
+- [ ] All defined qualities are normalization-reachable from source alias variants.
+- [ ] Canonical IDs are stable regardless of source alias format.
+- [ ] Existing core-quality normalization snapshots remain stable unless explicitly updated.
+- [ ] `npm test -- test/unit/normalize.test.ts test/unit/enharmonic.test.ts` exits `0`.
+- [ ] `npm run ingest` exits `0` with no normalization errors.
+- [ ] All Copilot inline review comments addressed
+- [ ] `require-copilot-review` CI check green before merge
+
+## Validation Steps
+
+```bash
+npm test -- test/unit/normalize.test.ts test/unit/enharmonic.test.ts
+npm run ingest
+```
+
+Expected outcome:
+- Both commands exit `0`.
+- Normalized output contains extended-quality canonical IDs with stable alias handling.

--- a/planning/issues/043-cli-filter-engine-generalization.md
+++ b/planning/issues/043-cli-filter-engine-generalization.md
@@ -1,0 +1,44 @@
+# Issue: CLI Filter Engine Generalization
+
+## Triage Labels
+
+- `status/backlog`
+- `priority/p2`
+- `area/ingest`
+
+**Depends on**: #038 — extended targets expand valid `--chord` match space
+**Depends on**: #042 — normalized IDs/qualities must be stable for filter matching
+
+## Summary
+
+Generalize ingest/build filtering so `--chord` and related matching logic are
+not constrained by MVP-only target assumptions.
+
+## Scope
+
+- Remove MVP-only matching assumptions in build filtering (`MVP_TARGETS`-based
+  slug lookup path).
+- Match canonical IDs and deterministic slug patterns across the expanded matrix.
+- Keep existing `--source`, `--chord`, and `--dry-run` semantics intact.
+- Update CLI help text/examples and `README.md` command examples accordingly.
+
+## Acceptance Criteria
+
+- [ ] `--chord` matching works for extended-quality canonical IDs.
+- [ ] Build/ingest filters no longer depend on MVP-only target subsets.
+- [ ] CLI help and README examples reflect expanded quality coverage.
+- [ ] `npm test -- test/unit/cliOptions.test.ts test/unit/buildCli.test.ts` exits `0`.
+- [ ] `npm run build -- --dry-run --chord chord:C:dim7` exits `0` when the chord exists in normalized input.
+- [ ] All Copilot inline review comments addressed
+- [ ] `require-copilot-review` CI check green before merge
+
+## Validation Steps
+
+```bash
+npm test -- test/unit/cliOptions.test.ts test/unit/buildCli.test.ts
+npm run build -- --dry-run --chord chord:C:dim7
+```
+
+Expected outcome:
+- Both commands exit `0`.
+- Filter behavior is deterministic and supports non-core qualities.

--- a/planning/issues/044-coverage-gate-enforcement-in-validate-and-ci.md
+++ b/planning/issues/044-coverage-gate-enforcement-in-validate-and-ci.md
@@ -1,0 +1,48 @@
+# Issue: Coverage Gate Enforcement in Validate and CI
+
+## Triage Labels
+
+- `status/backlog`
+- `priority/p0`
+- `area/ci-test`
+
+**Depends on**: #037 — requires explicit coverage matrix contract
+**Depends on**: #042 — enforcement must operate on stable normalized quality mapping
+**Depends on**: #049 — full voicing and quality ingestion baseline should be completed first
+
+## Summary
+
+Promote root-quality coverage from informational logs to a policy gate with
+deterministic pass/fail behavior in local validate runs and CI.
+
+## Scope
+
+- Add configurable coverage gate rules in validate (for example:
+  strict full-matrix mode and temporary allowlist-based exceptions).
+- Emit machine-readable coverage report artifact (`json`) in a deterministic form.
+- Wire CI to persist the coverage artifact and fail when gate policy is violated.
+- Document gate configuration and default policy in `README.md`.
+
+## Acceptance Criteria
+
+- [ ] `npm run validate` enforces the configured coverage policy deterministically.
+- [ ] Coverage artifact is generated with stable field ordering/content.
+- [ ] CI fails when policy is violated and uploads coverage artifact on every run.
+- [ ] Default gate policy requires full defined-quality matrix coverage (or explicit allowlist entries).
+- [ ] `npm test -- test/unit/coverage.test.ts test/unit/schema.test.ts` exits `0`.
+- [ ] `npm run validate` exits `0` only when full matrix policy is satisfied.
+- [ ] `env VALIDATE_REQUIRE_FULL_MATRIX=1 npm run validate` exits non-zero in local negative test when matrix gaps exist.
+- [ ] All Copilot inline review comments addressed
+- [ ] `require-copilot-review` CI check green before merge
+
+## Validation Steps
+
+```bash
+npm test -- test/unit/coverage.test.ts test/unit/schema.test.ts
+npm run validate
+env VALIDATE_REQUIRE_FULL_MATRIX=1 npm run validate
+```
+
+Expected outcome:
+- First two commands exit `0`.
+- The final command exits non-zero and prints a clear coverage gate failure reason.

--- a/planning/issues/045-ci-freshness-and-cache-audit-automation.md
+++ b/planning/issues/045-ci-freshness-and-cache-audit-automation.md
@@ -1,0 +1,46 @@
+# Issue: CI Freshness and Cache Audit Automation
+
+## Triage Labels
+
+- `status/backlog`
+- `priority/p2`
+- `area/ci-test`
+
+**Suggested after**: #039 — source capability/skip semantics improve freshness triage signal quality
+
+## Summary
+
+Automate source cache health checks in CI so stale/corrupt caches are detected
+without relying on manual local runs.
+
+## Scope
+
+- Add CI workflow coverage for:
+  - `npm run audit-cache`
+  - `npm run source-freshness -- --as-of <pinned-iso>`
+- Upload cache audit and freshness outputs as CI artifacts.
+- Define fail/warn behavior:
+  - fail on missing/corrupt cache entries
+  - warn (non-fail) on stale entries by default
+- Document policy in `docs/contributing/source-freshness-report.md`.
+
+## Acceptance Criteria
+
+- [ ] CI runs cache audit and source freshness checks on PRs.
+- [ ] CI artifacts include deterministic freshness/audit outputs.
+- [ ] Missing/corrupt cache causes CI failure; stale age threshold remains configurable.
+- [ ] `npm run audit-cache` exits `0` on healthy cache state.
+- [ ] `npm run source-freshness -- --as-of 2026-02-27T00:00:00.000Z --max-age-days 30` exits `0`.
+- [ ] All Copilot inline review comments addressed
+- [ ] `require-copilot-review` CI check green before merge
+
+## Validation Steps
+
+```bash
+npm run audit-cache
+npm run source-freshness -- --as-of 2026-02-27T00:00:00.000Z --max-age-days 30
+```
+
+Expected outcome:
+- Both commands exit `0`.
+- Outputs are deterministic for the pinned `--as-of` timestamp.

--- a/planning/issues/046-docs-coverage-dashboard-generation.md
+++ b/planning/issues/046-docs-coverage-dashboard-generation.md
@@ -1,0 +1,43 @@
+# Issue: Docs Coverage Dashboard Generation
+
+## Triage Labels
+
+- `status/backlog`
+- `priority/p2`
+- `area/docs-svg`
+
+**Depends on**: #044 — consumes coverage gate/report output
+
+## Summary
+
+Generate a deterministic Markdown coverage dashboard under `docs/` so humans
+can quickly inspect matrix progress, missing qualities, and severity totals.
+
+## Scope
+
+- Add a docs generator step that emits `docs/coverage.md` from coverage report data.
+- Include:
+  - current coverage percent and observed/expected counts
+  - missing severity counts
+  - deterministic missing-ID table (or bounded list with deterministic truncation)
+- Link coverage dashboard from `docs/index.md`.
+- Add docs generator tests for deterministic output.
+
+## Acceptance Criteria
+
+- [ ] `docs/coverage.md` is generated deterministically on `npm run build`.
+- [ ] Coverage dashboard is linked from `docs/index.md`.
+- [ ] Tests assert stable dashboard content and ordering.
+- [ ] `npm test -- test/unit/docs.test.ts test/unit/sitemap.test.ts` exits `0`.
+- [ ] `npm run build` exits `0` and writes `docs/coverage.md`.
+
+## Validation Steps
+
+```bash
+npm test -- test/unit/docs.test.ts test/unit/sitemap.test.ts
+npm run build
+```
+
+Expected outcome:
+- Both commands exit `0`.
+- Generated `docs/coverage.md` reflects deterministic coverage summary content.

--- a/planning/issues/047-parser-confidence-reporting-pipeline.md
+++ b/planning/issues/047-parser-confidence-reporting-pipeline.md
@@ -1,0 +1,43 @@
+# Issue: Parser Confidence Reporting Pipeline
+
+## Triage Labels
+
+- `status/backlog`
+- `priority/p2`
+- `area/ci-test`
+
+**Depends on**: #041 — confidence reporting depends on reliable extended-quality parser output
+
+## Summary
+
+Operationalize parser confidence annotations into a deterministic summary report
+for CI and source quality triage.
+
+## Scope
+
+- Add confidence aggregation (`high` / `medium` / `low`) by source and quality.
+- Emit a machine-readable report artifact in `data/generated/` during ingest when
+  parser confidence is included.
+- Add tests covering aggregation and deterministic ordering.
+- Document confidence report usage in `docs/contributing/parser-confidence-annotations.md`.
+
+## Acceptance Criteria
+
+- [ ] Confidence report generation is deterministic and source/quality grouped.
+- [ ] Report is emitted when running ingest with confidence enabled.
+- [ ] Tests validate report aggregation and ordering.
+- [ ] `npm test -- test/unit/pipeline.test.ts test/unit/freshnessReport.test.ts` exits `0`.
+- [ ] `npm run ingest -- --include-parser-confidence` exits `0` and writes confidence report output.
+- [ ] All Copilot inline review comments addressed
+- [ ] `require-copilot-review` CI check green before merge
+
+## Validation Steps
+
+```bash
+npm test -- test/unit/pipeline.test.ts test/unit/freshnessReport.test.ts
+npm run ingest -- --include-parser-confidence
+```
+
+Expected outcome:
+- Both commands exit `0`.
+- Ingest writes a deterministic confidence summary artifact for triage.

--- a/planning/issues/048-fixture-cache-parity-checks.md
+++ b/planning/issues/048-fixture-cache-parity-checks.md
@@ -1,0 +1,41 @@
+# Issue: Fixture-Cache Parity Checks
+
+## Triage Labels
+
+- `status/backlog`
+- `priority/p1`
+- `area/ingest`
+
+**Depends on**: #038 — parity rules must reflect expanded target matrix
+
+## Summary
+
+Add automated parity checks to detect drift between ingest targets, cached
+source HTML under `data/sources/`, and parser fixtures under `test/fixtures/`.
+
+## Scope
+
+- Add parity validation logic for:
+  - target slug existence in cache directories
+  - expected fixture presence for parser-covered scenarios
+  - deterministic missing/extra listing for diagnostics
+- Add unit tests and fixture/cache parity snapshots for a representative subset.
+- Document parity expectations in `docs/contributing/parser-fixtures.md`.
+
+## Acceptance Criteria
+
+- [ ] Parity checks detect missing/extra cache or fixture entries deterministically.
+- [ ] Test suite includes parity assertions for representative targets.
+- [ ] `npm test -- test/unit/cache.test.ts test/unit/parser.invariants.test.ts` exits `0`.
+- [ ] `npm run lint` exits `0`.
+
+## Validation Steps
+
+```bash
+npm test -- test/unit/cache.test.ts test/unit/parser.invariants.test.ts
+npm run lint
+```
+
+Expected outcome:
+- Both commands exit `0`.
+- Parity diagnostics are deterministic and actionable when drift occurs.

--- a/planning/issues/049-full-voicing-coverage-across-defined-quality-matrix.md
+++ b/planning/issues/049-full-voicing-coverage-across-defined-quality-matrix.md
@@ -1,0 +1,45 @@
+# Issue: Full Voicing Coverage Across Defined-Quality Matrix
+
+## Triage Labels
+
+- `status/backlog`
+- `priority/p0`
+- `area/ingest`
+
+**Depends on**: #041 — parser quality extraction baseline must be in place
+**Depends on**: #042 — normalization must stabilize canonical IDs/aliases first
+
+## Summary
+
+Ensure ingest captures all statically available voicings for each chord across
+all defined qualities, with deterministic ordering and no parser-side truncation.
+
+## Scope
+
+- Audit both source parsers for voicing truncation logic and remove hard caps.
+- Add deterministic voicing count assertions for representative chord-quality
+  targets across both sources.
+- Ensure voicing IDs/order are deterministic and stable across repeated runs.
+- Preserve provenance for every voicing record (`source_refs` at voicing level).
+- Document voicing completeness expectations in contributor docs.
+
+## Acceptance Criteria
+
+- [ ] No parser-imposed voicing cap remains for defined-quality targets.
+- [ ] Representative regression tests assert complete voicing extraction against fixtures.
+- [ ] Repeated ingest/build runs produce stable voicing counts and ordering.
+- [ ] `npm test -- test/unit/parser.guitarChordOrg.test.ts test/unit/parser.allGuitarChords.test.ts test/unit/pipelineIdempotency.test.ts` exits `0`.
+- [ ] `npm run ingest && npm run build && npm run validate` exits `0`.
+- [ ] All Copilot inline review comments addressed
+- [ ] `require-copilot-review` CI check green before merge
+
+## Validation Steps
+
+```bash
+npm test -- test/unit/parser.guitarChordOrg.test.ts test/unit/parser.allGuitarChords.test.ts test/unit/pipelineIdempotency.test.ts
+npm run ingest && npm run build && npm run validate
+```
+
+Expected outcome:
+- Both commands exit `0`.
+- Ingest/build output shows deterministic voicing completeness with no truncation regressions.

--- a/planning/issues/050-generated-website-and-navigation.md
+++ b/planning/issues/050-generated-website-and-navigation.md
@@ -1,0 +1,49 @@
+# Issue: Generated Website and Navigation
+
+## Triage Labels
+
+- `status/backlog`
+- `priority/p2`
+- `area/docs-svg`
+
+**Depends on**: #046 — coverage dashboard and docs metadata should already be generated
+**Depends on**: #049 — full voicing coverage should be available before site rendering
+
+## Summary
+
+Generate a navigable static website from build outputs so users can browse the
+chord knowledge base by root, quality, and chord detail pages.
+
+## Scope
+
+- Add a site generation step that outputs static HTML/CSS assets from generated
+  chord data and diagrams.
+- Create:
+  - site home/index page with root/quality navigation
+  - per-chord pages with formula, notes, aliases, provenance, and embedded voicings
+  - cross-links between related/enharmonic chords
+- Ensure deterministic site output ordering and file naming.
+- Add responsive layout support for desktop and mobile browsing.
+- Add/update tests for site generation and link integrity.
+- Update `README.md` with local preview instructions for the generated site.
+
+## Acceptance Criteria
+
+- [ ] `npm run build` generates a static website output directory with index and chord detail pages.
+- [ ] Navigation links resolve correctly across index and chord pages.
+- [ ] Website rendering includes voicing diagrams and provenance blocks.
+- [ ] Site output is deterministic across repeated builds with identical inputs.
+- [ ] `npm test -- test/unit/docs.test.ts test/unit/links.test.ts` exits `0`.
+- [ ] `npm run check-links` exits `0`.
+
+## Validation Steps
+
+```bash
+npm run build
+npm test -- test/unit/docs.test.ts test/unit/links.test.ts
+npm run check-links
+```
+
+Expected outcome:
+- All commands exit `0`.
+- Generated site is navigable and stable across repeated builds.

--- a/planning/issues/051-website-publishing-pipeline.md
+++ b/planning/issues/051-website-publishing-pipeline.md
@@ -1,0 +1,44 @@
+# Issue: Website Publishing Pipeline
+
+## Triage Labels
+
+- `status/backlog`
+- `priority/p2`
+- `area/ci-test`
+
+**Depends on**: #050 — generated website output must exist before publish automation
+
+## Summary
+
+Add CI automation to publish the generated website artifact so the chord site
+is accessible without local build steps.
+
+## Scope
+
+- Add/update workflow(s) to build the static website from a clean checkout.
+- Publish site artifacts (for PR preview and/or main-branch deployment target).
+- Enforce link checks before publishing.
+- Upload published site bundle as an artifact for debugging reproducibility.
+- Document publish workflow and expected URL/path in `README.md`.
+
+## Acceptance Criteria
+
+- [ ] CI builds the generated website in a dedicated job.
+- [ ] Publish pipeline runs only after successful build/test/link checks.
+- [ ] Site artifact is uploaded deterministically on each run.
+- [ ] Deployment/publish behavior is documented for contributors.
+- [ ] `npm run build && npm run check-links` exits `0` locally.
+- [ ] All Copilot inline review comments addressed
+- [ ] `require-copilot-review` CI check green before merge
+
+## Validation Steps
+
+```bash
+npm run build && npm run check-links
+npm run lint
+npm test
+```
+
+Expected outcome:
+- All commands exit `0`.
+- CI workflow changes support deterministic site publish behavior.


### PR DESCRIPTION
## Summary
- seed planning wave D issue drafts (036-051)
- reprioritize backlog around full defined-quality coverage and full voicing completeness
- add generated website + publishing pipeline issues

## Why
This prepares the next execution cycle with implementation-ready, triaged issues and explicit dependencies.

## Validation
- planning docs only; no runtime code changes
- labels/dependency notation validated locally across 036-051