### PR TITLE
feat: harden normalization quality alias mapping

### DIFF
--- a/src/ingest/normalize/normalize.ts
+++ b/src/ingest/normalize/normalize.ts
@@ -75,6 +75,7 @@ export function detectAliasCollisions(chords: ChordRecord[]): void {
 
 const QUALITY_MAP: Record<string, ChordQuality> = {
   m: "min",
+  mi: "min",
   minor: "min",
   min: "min",
   "Δ": "maj",
@@ -87,17 +88,24 @@ const QUALITY_MAP: Record<string, ChordQuality> = {
   m7: "min7",
   "-7": "min7",
   minor7: "min7",
+  minor7th: "min7",
+  min7th: "min7",
   min7: "min7",
   "7": "7",
+  dominant7: "7",
+  dominant7th: "7",
   major7: "maj7",
+  major7th: "maj7",
   maj7: "maj7",
   m7b5: "dim",
+  halfdiminished: "dim",
   dim: "dim",
   diminished: "dim",
   "°": "dim",
   o: "dim",
   dim7: "dim7",
   diminished7: "dim7",
+  diminished7th: "dim7",
   "°7": "dim7",
   o7: "dim7",
   aug: "aug",
@@ -105,8 +113,10 @@ const QUALITY_MAP: Record<string, ChordQuality> = {
   augmented: "aug",
   sus2: "sus2",
   suspended2: "sus2",
+  suspended2nd: "sus2",
   sus4: "sus4",
   suspended4: "sus4",
+  suspended4th: "sus4",
   sus: "sus4"
 };
 
@@ -183,6 +193,14 @@ function normalizeStringArray(values: string[]): string[] {
   return [...unique];
 }
 
+function normalizeQualityToken(value: string): string {
+  return value
+    .trim()
+    .replace(/\s+/g, "")
+    .replace(/[-_.]/g, "")
+    .toLowerCase();
+}
+
 function defaultAlias(root: string, quality: ChordQuality): string {
   switch (quality) {
     case "maj":
@@ -232,7 +250,7 @@ export function normalizeQuality(qualityRaw: string): ChordQuality {
   }
 
   const key = rawTrimmed.toLowerCase();
-  const normalized = QUALITY_MAP[key];
+  const normalized = QUALITY_MAP[key] ?? QUALITY_MAP[normalizeQualityToken(rawTrimmed)];
   if (!normalized) {
     throw new Error(`Unsupported chord quality: ${qualityRaw}`);
   }

--- a/test/unit/enharmonic.test.ts
+++ b/test/unit/enharmonic.test.ts
@@ -38,6 +38,17 @@ describe("buildEnharmonicReport", () => {
     expect(report.recordsWithEnharmonics).toBe(2);
   });
 
+  it("detects symmetric pairs for extended-quality canonical IDs", () => {
+    const records = [
+      makeRecord("chord:C#:min7", ["chord:Db:min7"]),
+      makeRecord("chord:Db:min7", ["chord:C#:min7"]),
+    ];
+    const report = buildEnharmonicReport(records);
+    expect(report.pairs).toHaveLength(1);
+    expect(report.pairs[0]).toEqual({ a: "chord:C#:min7", b: "chord:Db:min7" });
+    expect(report.asymmetries).toHaveLength(0);
+  });
+
   it("does not duplicate symmetric pairs", () => {
     // Both sides refer to each other — should produce exactly one pair
     const records = [

--- a/test/unit/normalize.test.ts
+++ b/test/unit/normalize.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { AliasCollisionError, detectAliasCollisions, derivePosition, normalizeQuality, normalizeRecords } from "../../src/ingest/normalize/normalize.js";
-import type { ChordRecord, RawChordRecord } from "../../src/types/model.js";
+import type { ChordQuality, ChordRecord, RawChordRecord } from "../../src/types/model.js";
 
 describe("normalizeQuality", () => {
   it("maps canonical aliases", () => {
@@ -30,18 +30,22 @@ describe("normalizeQuality", () => {
     expect(normalizeQuality("m7")).toBe("min7");
     expect(normalizeQuality("min7")).toBe("min7");
     expect(normalizeQuality("minor7")).toBe("min7");
+    expect(normalizeQuality("minor 7th")).toBe("min7");
+    expect(normalizeQuality("minor-7th")).toBe("min7");
     expect(normalizeQuality("-7")).toBe("min7");
 
     // dim variants
     expect(normalizeQuality("dim")).toBe("dim");
     expect(normalizeQuality("diminished")).toBe("dim");
     expect(normalizeQuality("m7b5")).toBe("dim");
+    expect(normalizeQuality("half-diminished")).toBe("dim");
     expect(normalizeQuality("°")).toBe("dim");
     expect(normalizeQuality("o")).toBe("dim");
 
     // dim7 variants
     expect(normalizeQuality("dim7")).toBe("dim7");
     expect(normalizeQuality("diminished7")).toBe("dim7");
+    expect(normalizeQuality("diminished 7th")).toBe("dim7");
     expect(normalizeQuality("°7")).toBe("dim7");
     expect(normalizeQuality("o7")).toBe("dim7");
 
@@ -53,9 +57,15 @@ describe("normalizeQuality", () => {
     // sus variants
     expect(normalizeQuality("sus2")).toBe("sus2");
     expect(normalizeQuality("suspended2")).toBe("sus2");
+    expect(normalizeQuality("suspended-2nd")).toBe("sus2");
     expect(normalizeQuality("sus4")).toBe("sus4");
     expect(normalizeQuality("suspended4")).toBe("sus4");
+    expect(normalizeQuality("suspended 4th")).toBe("sus4");
     expect(normalizeQuality("sus")).toBe("sus4");
+
+    // dominant 7 variants
+    expect(normalizeQuality("dominant7")).toBe("7");
+    expect(normalizeQuality("dominant 7th")).toBe("7");
   });
 
   it("rejects unsupported aliases", () => {
@@ -292,6 +302,43 @@ describe("normalizeRecords", () => {
     });
     expect(new Set(ids).size).toBe(1);
     expect(ids[0]).toBe("chord:C:maj");
+  });
+
+  it("reaches all defined qualities via alias variants with stable canonical IDs", () => {
+    const variantsByQuality: Record<ChordQuality, string[]> = {
+      maj: ["major", "maj", "M", "Δ", ""],
+      min: ["minor", "min", "m"],
+      "7": ["7", "dominant7", "dominant 7th"],
+      maj7: ["maj7", "major7", "major-7th", "Δ7"],
+      min7: ["min7", "minor7", "minor 7th", "minor-7th", "m7"],
+      dim: ["dim", "diminished", "m7b5", "half-diminished", "°"],
+      dim7: ["dim7", "diminished7", "diminished 7th", "°7"],
+      aug: ["aug", "augmented", "+"],
+      sus2: ["sus2", "suspended2", "suspended-2nd"],
+      sus4: ["sus4", "suspended4", "suspended 4th", "sus"],
+    };
+
+    for (const [quality, variants] of Object.entries(variantsByQuality) as Array<[ChordQuality, string[]]>) {
+      const ids = variants.map((quality_raw) => {
+        const records = normalizeRecords([
+          {
+            source: "source-a",
+            url: "https://example.com/c",
+            symbol: "C",
+            root: "C",
+            quality_raw,
+            aliases: [],
+            formula: [],
+            pitch_classes: [],
+            voicings: [{ id: "v1", frets: [null, 3, 2, 0, 1, 0], base_fret: 1 }],
+          },
+        ]);
+        return records[0]?.id;
+      });
+
+      expect(new Set(ids).size, `quality ${quality} should normalize to one canonical ID`).toBe(1);
+      expect(ids[0]).toBe(`chord:C:${quality}`);
+    }
   });
 
   it("links enharmonic equivalents for all supported enharmonic root pairs", () => {


### PR DESCRIPTION
## Summary
- harden `normalizeQuality` with token compaction so whitespace/hyphen/underscore variants normalize deterministically
- extend quality alias coverage for extended qualities and dominant/seventh variants
- add stable canonical-ID reachability tests across all defined qualities and alias formats
- add extended-quality enharmonic pair coverage in enharmonic reporting tests

Closes #195

## Validation
- npm test -- --run test/unit/normalize.test.ts test/unit/enharmonic.test.ts
- npm run ingest
- npm run lint
- npm test
- npm run build
- npm run validate
