### PR TITLE
feat: parser confidence reporting pipeline

### DIFF
--- a/docs/contributing/parser-confidence-annotations.md
+++ b/docs/contributing/parser-confidence-annotations.md
@@ -30,4 +30,16 @@ To include confidence annotations in `data/generated/chords.normalized.json`:
 npm run ingest -- --include-parser-confidence
 ```
 
+When enabled, ingest also writes:
+
+- `data/generated/parser-confidence.report.json`
+
+The report is machine-readable and deterministic for identical normalized chord
+inputs. It includes:
+
+- overall confidence annotation totals (`high`, `medium`, `low`)
+- per-source confidence totals and per-quality breakdowns
+- aggregate per-quality confidence totals across all sources
+- deterministic list of chord IDs that have no confidence annotations
+
 This flag is intended for debugging and source-quality triage workflows.

--- a/src/cli/ingest.ts
+++ b/src/cli/ingest.ts
@@ -1,6 +1,7 @@
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { ingestNormalizedChords } from "../ingest/pipeline.js";
+import { buildParserConfidenceReport } from "../ingest/parserConfidenceReport.js";
 import { writeJson } from "../utils/fs.js";
 import { parseIngestCliOptions } from "./options.js";
 
@@ -22,6 +23,10 @@ async function main(): Promise<void> {
 
   await mkdir(path.join("data", "generated"), { recursive: true });
   await writeJson(path.join("data", "generated", "chords.normalized.json"), chords);
+  if (options.includeParserConfidence) {
+    const report = buildParserConfidenceReport(chords);
+    await writeJson(path.join("data", "generated", "parser-confidence.report.json"), report);
+  }
 
   process.stdout.write(`Ingested ${chords.length} normalized chords\n`);
 }

--- a/src/ingest/parserConfidenceReport.ts
+++ b/src/ingest/parserConfidenceReport.ts
@@ -1,0 +1,196 @@
+import { QUALITY_ORDER } from "../config.js";
+import type {
+  ChordRecord,
+  ChordQuality,
+  ParserConfidenceLevel,
+} from "../types/model.js";
+
+const CONFIDENCE_LEVEL_ORDER: ReadonlyArray<ParserConfidenceLevel> = ["high", "medium", "low"];
+
+export interface ParserConfidenceCounts {
+  high: number;
+  medium: number;
+  low: number;
+}
+
+export interface ParserConfidenceQualitySummary {
+  quality: ChordQuality;
+  chords: number;
+  annotations: number;
+  levels: ParserConfidenceCounts;
+}
+
+export interface ParserConfidenceSourceSummary {
+  source: string;
+  chords: number;
+  annotations: number;
+  levels: ParserConfidenceCounts;
+  qualities: ParserConfidenceQualitySummary[];
+}
+
+export interface ParserConfidenceReport {
+  totalChords: number;
+  chordsWithConfidence: number;
+  chordsWithoutConfidence: string[];
+  annotations: number;
+  levels: ParserConfidenceCounts;
+  sources: ParserConfidenceSourceSummary[];
+  qualities: ParserConfidenceQualitySummary[];
+}
+
+interface MutableSummaryBucket {
+  chords: Set<string>;
+  annotations: number;
+  levels: ParserConfidenceCounts;
+}
+
+interface MutableSourceSummary {
+  summary: MutableSummaryBucket;
+  qualities: Map<ChordQuality, MutableSummaryBucket>;
+}
+
+function createCounts(): ParserConfidenceCounts {
+  return {
+    high: 0,
+    medium: 0,
+    low: 0,
+  };
+}
+
+function createBucket(): MutableSummaryBucket {
+  return {
+    chords: new Set<string>(),
+    annotations: 0,
+    levels: createCounts(),
+  };
+}
+
+function addToBucket(bucket: MutableSummaryBucket, chordId: string, level: ParserConfidenceLevel): void {
+  bucket.chords.add(chordId);
+  bucket.annotations += 1;
+  bucket.levels[level] += 1;
+}
+
+function finalizeBucket(
+  key: { source: string } | { quality: ChordQuality },
+  bucket: MutableSummaryBucket,
+): ParserConfidenceSourceSummary | ParserConfidenceQualitySummary {
+  if ("source" in key) {
+    return {
+      source: key.source,
+      chords: bucket.chords.size,
+      annotations: bucket.annotations,
+      levels: { ...bucket.levels },
+      qualities: [],
+    };
+  }
+
+  return {
+    quality: key.quality,
+    chords: bucket.chords.size,
+    annotations: bucket.annotations,
+    levels: { ...bucket.levels },
+  };
+}
+
+function compareQuality(a: ChordQuality, b: ChordQuality): number {
+  const aIndex = QUALITY_ORDER.indexOf(a);
+  const bIndex = QUALITY_ORDER.indexOf(b);
+  if (aIndex !== -1 && bIndex !== -1 && aIndex !== bIndex) {
+    return aIndex - bIndex;
+  }
+  if (aIndex === -1 && bIndex !== -1) {
+    return 1;
+  }
+  if (aIndex !== -1 && bIndex === -1) {
+    return -1;
+  }
+  return a.localeCompare(b);
+}
+
+export function buildParserConfidenceReport(chords: ReadonlyArray<ChordRecord>): ParserConfidenceReport {
+  const sourceSummaries = new Map<string, MutableSourceSummary>();
+  const qualitySummaries = new Map<ChordQuality, MutableSummaryBucket>();
+  const overall = createBucket();
+  const chordsWithConfidence = new Set<string>();
+  const chordsWithoutConfidence: string[] = [];
+
+  const ensureSourceSummary = (source: string): MutableSourceSummary => {
+    const existing = sourceSummaries.get(source);
+    if (existing) {
+      return existing;
+    }
+    const created: MutableSourceSummary = {
+      summary: createBucket(),
+      qualities: new Map<ChordQuality, MutableSummaryBucket>(),
+    };
+    sourceSummaries.set(source, created);
+    return created;
+  };
+
+  const ensureQualityBucket = (
+    map: Map<ChordQuality, MutableSummaryBucket>,
+    quality: ChordQuality,
+  ): MutableSummaryBucket => {
+    const existing = map.get(quality);
+    if (existing) {
+      return existing;
+    }
+    const created = createBucket();
+    map.set(quality, created);
+    return created;
+  };
+
+  for (const chord of chords) {
+    const confidenceEntries = chord.parser_confidence ?? [];
+    if (confidenceEntries.length === 0) {
+      chordsWithoutConfidence.push(chord.id);
+      continue;
+    }
+
+    chordsWithConfidence.add(chord.id);
+
+    for (const entry of confidenceEntries) {
+      addToBucket(overall, chord.id, entry.level);
+
+      const sourceSummary = ensureSourceSummary(entry.source);
+      addToBucket(sourceSummary.summary, chord.id, entry.level);
+      addToBucket(ensureQualityBucket(sourceSummary.qualities, chord.quality), chord.id, entry.level);
+
+      addToBucket(ensureQualityBucket(qualitySummaries, chord.quality), chord.id, entry.level);
+    }
+  }
+
+  chordsWithoutConfidence.sort((a, b) => a.localeCompare(b));
+
+  const sources = Array.from(sourceSummaries.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([source, summary]): ParserConfidenceSourceSummary => {
+      const finalized = finalizeBucket({ source }, summary.summary) as ParserConfidenceSourceSummary;
+      finalized.qualities = Array.from(summary.qualities.entries())
+        .sort(([a], [b]) => compareQuality(a, b))
+        .map(([quality, bucket]) => finalizeBucket({ quality }, bucket) as ParserConfidenceQualitySummary);
+      return finalized;
+    });
+
+  const qualities = Array.from(qualitySummaries.entries())
+    .sort(([a], [b]) => compareQuality(a, b))
+    .map(([quality, bucket]) => finalizeBucket({ quality }, bucket) as ParserConfidenceQualitySummary);
+
+  // Assert level key presence at construction time to keep output shape stable.
+  for (const level of CONFIDENCE_LEVEL_ORDER) {
+    if (!(level in overall.levels)) {
+      throw new Error(`Missing parser confidence level bucket: ${level}`);
+    }
+  }
+
+  return {
+    totalChords: chords.length,
+    chordsWithConfidence: chordsWithConfidence.size,
+    chordsWithoutConfidence,
+    annotations: overall.annotations,
+    levels: { ...overall.levels },
+    sources,
+    qualities,
+  };
+}

--- a/test/unit/pipeline.test.ts
+++ b/test/unit/pipeline.test.ts
@@ -10,7 +10,8 @@ import {
   ingestNormalizedChordsWithTargets,
   selectIngestTargets,
 } from "../../src/ingest/pipeline.js";
-import type { SourceRegistryEntry } from "../../src/types/model.js";
+import { buildParserConfidenceReport } from "../../src/ingest/parserConfidenceReport.js";
+import type { ChordRecord, SourceRegistryEntry } from "../../src/types/model.js";
 
 describe("ingestNormalizedChords", () => {
   afterEach(() => {
@@ -292,5 +293,109 @@ describe("ingestNormalizedChords", () => {
     const output = writeSpy.mock.calls.map(([line]) => String(line)).join("");
     expect(output).toContain("GAP_ALLOWLISTED chord=chord:C:min7 unsupported_sources=stub-source");
     expect(output).not.toContain("GAP_UNRESOLVED chord=chord:C:min7");
+  });
+
+  it("builds deterministic parser confidence summaries grouped by source and quality", () => {
+    const chords: ChordRecord[] = [
+      {
+        id: "chord:D:min7",
+        root: "D",
+        quality: "min7",
+        aliases: [],
+        formula: ["1", "b3", "5", "b7"],
+        pitch_classes: ["D", "F", "A", "C"],
+        voicings: [],
+        parser_confidence: [
+          { source: "source-b", level: "medium", checks: ["has_formula"] },
+          { source: "source-a", level: "high", checks: ["all_voicings_complete"] },
+        ],
+        source_refs: [{ source: "fixture", url: "https://example.test/d-min7" }],
+      },
+      {
+        id: "chord:C:maj",
+        root: "C",
+        quality: "maj",
+        aliases: [],
+        formula: ["1", "3", "5"],
+        pitch_classes: ["C", "E", "G"],
+        voicings: [],
+        parser_confidence: [
+          { source: "source-a", level: "low", checks: ["missing_voicings"] },
+        ],
+        source_refs: [{ source: "fixture", url: "https://example.test/c-major" }],
+      },
+      {
+        id: "chord:A:dim",
+        root: "A",
+        quality: "dim",
+        aliases: [],
+        formula: ["1", "b3", "b5"],
+        pitch_classes: ["A", "C", "Eb"],
+        voicings: [],
+        source_refs: [{ source: "fixture", url: "https://example.test/a-dim" }],
+      },
+    ];
+
+    const report = buildParserConfidenceReport(chords);
+    const reversedReport = buildParserConfidenceReport([...chords].reverse());
+
+    expect(reversedReport).toEqual(report);
+    expect(report).toEqual({
+      totalChords: 3,
+      chordsWithConfidence: 2,
+      chordsWithoutConfidence: ["chord:A:dim"],
+      annotations: 3,
+      levels: { high: 1, medium: 1, low: 1 },
+      sources: [
+        {
+          source: "source-a",
+          chords: 2,
+          annotations: 2,
+          levels: { high: 1, medium: 0, low: 1 },
+          qualities: [
+            {
+              quality: "maj",
+              chords: 1,
+              annotations: 1,
+              levels: { high: 0, medium: 0, low: 1 },
+            },
+            {
+              quality: "min7",
+              chords: 1,
+              annotations: 1,
+              levels: { high: 1, medium: 0, low: 0 },
+            },
+          ],
+        },
+        {
+          source: "source-b",
+          chords: 1,
+          annotations: 1,
+          levels: { high: 0, medium: 1, low: 0 },
+          qualities: [
+            {
+              quality: "min7",
+              chords: 1,
+              annotations: 1,
+              levels: { high: 0, medium: 1, low: 0 },
+            },
+          ],
+        },
+      ],
+      qualities: [
+        {
+          quality: "maj",
+          chords: 1,
+          annotations: 1,
+          levels: { high: 0, medium: 0, low: 1 },
+        },
+        {
+          quality: "min7",
+          chords: 1,
+          annotations: 2,
+          levels: { high: 1, medium: 1, low: 0 },
+        },
+      ],
+    });
   });
 });


### PR DESCRIPTION
## Summary
- add deterministic parser confidence aggregation grouped by source and quality
- emit `data/generated/parser-confidence.report.json` during ingest when `--include-parser-confidence` is enabled
- document confidence report output and add pipeline tests for aggregation/ordering stability

Closes #200

## Validation
- npm test -- test/unit/pipeline.test.ts test/unit/freshnessReport.test.ts
- npm run ingest -- --include-parser-confidence
- npm run lint