### PR TITLE
feat: generate static website and navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ docs/chords/
 docs/diagrams/
 docs/index.md
 docs/coverage.md
+/site/

--- a/README.md
+++ b/README.md
@@ -32,12 +32,14 @@ End-to-end pipeline:
 - `data/chords.jsonl` (primary machine-consumable output)
 - `docs/chords/*.md` (per-chord documentation)
 - `docs/diagrams/*.svg` (generated voicing diagrams)
+- `site/index.html` + `site/chords/*.html` (generated static website)
+- `site/diagrams/*.svg` (website diagram assets)
 
 ### Artifact versioning policy
 
 Source cache (`data/sources/**/*.html`) is **committed** to enable deterministic, offline builds.
 
-All generated outputs (`data/generated/`, `data/chords.jsonl`, `docs/chords/`, `docs/diagrams/`) are **excluded from git** via `.gitignore`. They are fully reproducible by running `npm run build`. Committing generated outputs would create noisy diffs and risk stale artifacts drifting from the build scripts.
+All generated outputs (`data/generated/`, `data/chords.jsonl`, `docs/chords/`, `docs/diagrams/`, `site/`) are **excluded from git** via `.gitignore`. They are fully reproducible by running `npm run build`. Committing generated outputs would create noisy diffs and risk stale artifacts drifting from the build scripts.
 
 Full policy: [`planning/decisions/0004-artifact-versioning-policy.md`](planning/decisions/0004-artifact-versioning-policy.md)
 
@@ -49,6 +51,7 @@ Full policy: [`planning/decisions/0004-artifact-versioning-policy.md`](planning/
 - `src/ingest/normalize/*` – canonical record normalization
 - `src/build/output/*` – JSONL output writer
 - `src/build/docs/*` – Markdown generation
+- `src/build/site/*` – static website generation
 - `src/build/svg/*` – SVG diagram generation
 - `src/validate/*` – schema validation
 - `src/types/*` – core data model and guards
@@ -133,7 +136,15 @@ Build behavior:
 - otherwise generates normalized records via ingest pipeline
 - sorts records deterministically
 - validates records
-- regenerates JSONL/docs/SVG artifacts
+- regenerates JSONL/docs/SVG/static-site artifacts
+
+Local website preview:
+
+```bash
+python3 -m http.server --directory site 4173
+```
+
+Then open: `http://localhost:4173`
 
 To dry-run build output selection for an extended-quality canonical chord ID:
 

--- a/src/build/site/generateSite.ts
+++ b/src/build/site/generateSite.ts
@@ -1,0 +1,321 @@
+import { voicingDiagramFileName, encodeIdForPathSegment } from "../docs/paths.js";
+import type { ChordRecord } from "../../types/model.js";
+import { compareChordOrder } from "../../utils/sort.js";
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll("\"", "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function chordFileName(chordId: string): string {
+  return `${encodeIdForPathSegment(chordId)}.html`;
+}
+
+function chordHrefFromIndex(chordId: string): string {
+  return `./chords/${chordFileName(chordId)}`;
+}
+
+function chordHrefFromChordPage(chordId: string): string {
+  return `./${chordFileName(chordId)}`;
+}
+
+function diagramHref(voicingId: string): string {
+  return `../diagrams/${voicingDiagramFileName(voicingId)}`;
+}
+
+function rootAnchorId(root: string): string {
+  const token = root
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return `root-${token || "x"}`;
+}
+
+function enharmonicLinkIds(chord: ChordRecord, allChords: ChordRecord[]): string[] {
+  const byId = new Map(allChords.map((entry) => [entry.id, entry]));
+  const related = new Set<string>();
+
+  for (const candidate of chord.enharmonic_equivalents ?? []) {
+    if (byId.has(candidate) && candidate !== chord.id) {
+      related.add(candidate);
+    }
+  }
+
+  for (const candidate of allChords) {
+    if ((candidate.enharmonic_equivalents ?? []).includes(chord.id) && candidate.id !== chord.id) {
+      related.add(candidate.id);
+    }
+  }
+
+  return Array.from(related).sort((a, b) => {
+    const left = byId.get(a);
+    const right = byId.get(b);
+    if (!left || !right) {
+      return a.localeCompare(b);
+    }
+    return compareChordOrder(left, right);
+  });
+}
+
+function relatedQualityLinkIds(chord: ChordRecord, allChords: ChordRecord[]): string[] {
+  return allChords
+    .filter((candidate) => candidate.root === chord.root && candidate.id !== chord.id)
+    .slice()
+    .sort(compareChordOrder)
+    .map((candidate) => candidate.id);
+}
+
+function htmlFrame(title: string, stylesheetHref: string, body: string): string {
+  return [
+    "<!doctype html>",
+    '<html lang="en">',
+    "<head>",
+    '  <meta charset="utf-8">',
+    '  <meta name="viewport" content="width=device-width, initial-scale=1">',
+    `  <title>${escapeHtml(title)}</title>`,
+    `  <link rel="stylesheet" href="${escapeHtml(stylesheetHref)}">`,
+    "</head>",
+    "<body>",
+    "  <div class=\"aurora\" aria-hidden=\"true\"></div>",
+    `  <main class="page">${body}</main>`,
+    "</body>",
+    "</html>",
+    "",
+  ].join("\n");
+}
+
+export function siteStylesheet(): string {
+  return [
+    ":root {",
+    "  --bg: #f4f2ec;",
+    "  --paper: #fffdf9;",
+    "  --ink: #1f2529;",
+    "  --muted: #55616a;",
+    "  --accent: #175f6a;",
+    "  --accent-soft: #dff2f5;",
+    "  --line: #cfd8dd;",
+    "  --radius: 14px;",
+    "  --shadow: 0 12px 28px rgba(21, 44, 49, 0.12);",
+    "}",
+    "",
+    "* { box-sizing: border-box; }",
+    "html, body { margin: 0; padding: 0; }",
+    "body {",
+    "  font-family: \"Avenir Next\", \"Gill Sans\", \"Trebuchet MS\", sans-serif;",
+    "  color: var(--ink);",
+    "  background: radial-gradient(circle at 8% -10%, #d6eef2 0%, transparent 40%),",
+    "    radial-gradient(circle at 100% 0%, #f8e9d5 0%, transparent 36%),",
+    "    var(--bg);",
+    "}",
+    ".aurora {",
+    "  position: fixed;",
+    "  inset: 0;",
+    "  pointer-events: none;",
+    "  background: linear-gradient(135deg, rgba(23, 95, 106, 0.07), rgba(201, 119, 63, 0.06));",
+    "}",
+    ".page {",
+    "  position: relative;",
+    "  max-width: 1080px;",
+    "  margin: 0 auto;",
+    "  padding: 28px 20px 56px;",
+    "}",
+    ".hero {",
+    "  background: var(--paper);",
+    "  border: 1px solid var(--line);",
+    "  border-radius: calc(var(--radius) + 4px);",
+    "  padding: 24px;",
+    "  box-shadow: var(--shadow);",
+    "}",
+    ".hero h1 { margin: 0 0 8px; font-size: clamp(1.8rem, 3vw, 2.5rem); }",
+    ".hero p { margin: 0; color: var(--muted); }",
+    ".chip-row {",
+    "  margin-top: 18px;",
+    "  display: flex;",
+    "  flex-wrap: wrap;",
+    "  gap: 8px;",
+    "}",
+    ".chip {",
+    "  display: inline-block;",
+    "  padding: 6px 10px;",
+    "  border-radius: 999px;",
+    "  border: 1px solid var(--line);",
+    "  background: #fff;",
+    "  color: var(--ink);",
+    "  text-decoration: none;",
+    "  font-size: 0.88rem;",
+    "}",
+    ".grid {",
+    "  margin-top: 18px;",
+    "  display: grid;",
+    "  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));",
+    "  gap: 14px;",
+    "}",
+    ".card {",
+    "  background: var(--paper);",
+    "  border: 1px solid var(--line);",
+    "  border-radius: var(--radius);",
+    "  padding: 16px;",
+    "}",
+    ".card h2, .card h3 { margin-top: 0; }",
+    ".meta { color: var(--muted); font-size: 0.92rem; }",
+    ".quality-list, .plain-list { margin: 12px 0 0; padding-left: 18px; }",
+    ".quality-list li, .plain-list li { margin: 6px 0; }",
+    ".quality-list a, .plain-list a, .back-link { color: var(--accent); text-decoration: none; }",
+    ".quality-list a:hover, .plain-list a:hover, .back-link:hover { text-decoration: underline; }",
+    ".section { margin-top: 16px; }",
+    ".voicing-grid {",
+    "  display: grid;",
+    "  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));",
+    "  gap: 12px;",
+    "}",
+    ".voicing-card img { width: 100%; height: auto; background: #fff; border-radius: 10px; border: 1px solid var(--line); }",
+    ".voicing-card code { font-size: 0.85rem; color: var(--muted); }",
+    "@media (max-width: 680px) {",
+    "  .page { padding: 16px 14px 40px; }",
+    "  .hero { padding: 18px; }",
+    "}",
+    "",
+  ].join("\n");
+}
+
+export function siteIndexHtml(chords: ReadonlyArray<ChordRecord>): string {
+  const sorted = chords.slice().sort(compareChordOrder);
+  const grouped = new Map<string, ChordRecord[]>();
+
+  for (const chord of sorted) {
+    const group = grouped.get(chord.root) ?? [];
+    group.push(chord);
+    grouped.set(chord.root, group);
+  }
+
+  const roots = Array.from(grouped.keys());
+  const rootChips = roots
+    .map((root) => `<a class="chip" href="#${escapeHtml(rootAnchorId(root))}">${escapeHtml(root)}</a>`)
+    .join("");
+
+  const rootSections = Array.from(grouped.entries())
+    .map(([root, rootChords]) => {
+      const rows = rootChords.map((chord) => {
+        const aliases = (chord.aliases ?? []).join(", ") || "none";
+        return [
+          "<li>",
+          `  <a href="${escapeHtml(chordHrefFromIndex(chord.id))}">`,
+          `    <strong>${escapeHtml(chord.quality)}</strong>`,
+          `    <span class="meta"> ${escapeHtml(chord.id)} | aliases: ${escapeHtml(aliases)}</span>`,
+          "  </a>",
+          "</li>",
+        ].join("\n");
+      }).join("\n");
+
+      return [
+        `<section id="${escapeHtml(rootAnchorId(root))}" class="card">`,
+        `  <h2>${escapeHtml(root)}</h2>`,
+        "  <ul class=\"quality-list\">",
+        rows,
+        "  </ul>",
+        "</section>",
+      ].join("\n");
+    })
+    .join("\n");
+
+  const body = [
+    "<header class=\"hero\">",
+    "  <h1>Guitar Chord Knowledge Base</h1>",
+    `  <p>Browse ${sorted.length} canonical chords by root and quality.</p>`,
+    `  <nav class="chip-row" aria-label="Root navigation">${rootChips}</nav>`,
+    "</header>",
+    "<section class=\"grid section\">",
+    rootSections,
+    "</section>",
+  ].join("\n");
+
+  return htmlFrame("Guitar Chord Knowledge Base", "./assets/site.css", body);
+}
+
+function renderChordLinkList(ids: string[], byId: Map<string, ChordRecord>): string {
+  if (ids.length === 0) {
+    return "<li>none</li>";
+  }
+  return ids
+    .map((id) => {
+      const chord = byId.get(id);
+      if (!chord) {
+        return "";
+      }
+      return `<li><a href="${escapeHtml(chordHrefFromChordPage(chord.id))}">${escapeHtml(`${chord.root} ${chord.quality}`)}</a></li>`;
+    })
+    .filter((line) => line.length > 0)
+    .join("\n");
+}
+
+export function siteChordHtml(chord: ChordRecord, allChords: ReadonlyArray<ChordRecord>): string {
+  const sortedAll = allChords.slice().sort(compareChordOrder);
+  const byId = new Map(sortedAll.map((entry) => [entry.id, entry]));
+
+  const aliasText = (chord.aliases ?? []).join(", ") || "none";
+  const enharmonicRows = renderChordLinkList(enharmonicLinkIds(chord, sortedAll), byId);
+  const relatedRows = renderChordLinkList(relatedQualityLinkIds(chord, sortedAll), byId);
+  const voicingRows = chord.voicings
+    .slice()
+    .sort((a, b) => a.id.localeCompare(b.id))
+    .map((voicing) => {
+      const frets = voicing.frets.map((fret) => (fret === null ? "x" : String(fret))).join("/");
+      return [
+        "<article class=\"card voicing-card\">",
+        `  <h3>${escapeHtml(voicing.id)}</h3>`,
+        `  <img src="${escapeHtml(diagramHref(voicing.id))}" alt="${escapeHtml(`${chord.root} ${chord.quality} ${voicing.id}`)}" loading="lazy">`,
+        `  <p class="meta">frets ${escapeHtml(frets)} | base fret ${voicing.base_fret}</p>`,
+        `  <code>${escapeHtml(diagramHref(voicing.id))}</code>`,
+        "</article>",
+      ].join("\n");
+    })
+    .join("\n");
+
+  const provenanceRows = chord.source_refs
+    .map((source) => `<li><a href="${escapeHtml(source.url)}">${escapeHtml(source.source)}</a></li>`)
+    .join("\n");
+
+  const body = [
+    "<header class=\"hero\">",
+    `  <p><a class="back-link" href="../index.html">← Back to index</a></p>`,
+    `  <h1>${escapeHtml(`${chord.root} ${chord.quality}`)}</h1>`,
+    `  <p class="meta">${escapeHtml(chord.id)}</p>`,
+    "</header>",
+    "<section class=\"grid section\">",
+    "  <article class=\"card\">",
+    "    <h2>Chord Details</h2>",
+    `    <p><strong>Aliases:</strong> ${escapeHtml(aliasText)}</p>`,
+    `    <p><strong>Formula:</strong> ${escapeHtml(chord.formula.join("-"))}</p>`,
+    `    <p><strong>Pitch classes:</strong> ${escapeHtml(chord.pitch_classes.join(", "))}</p>`,
+    `    <p><strong>Summary:</strong> ${escapeHtml(chord.notes?.summary ?? "Chord reference generated from factual source data.")}</p>`,
+    "  </article>",
+    "  <article class=\"card\">",
+    "    <h2>Navigation</h2>",
+    "    <h3>Enharmonic equivalents</h3>",
+    `    <ul class="plain-list">${enharmonicRows}</ul>`,
+    "    <h3>Related qualities</h3>",
+    `    <ul class="plain-list">${relatedRows}</ul>`,
+    "  </article>",
+    "  <article class=\"card\">",
+    "    <h2>Provenance</h2>",
+    `    <ul class="plain-list">${provenanceRows}</ul>`,
+    "  </article>",
+    "</section>",
+    "<section class=\"section\">",
+    "  <h2>Voicings</h2>",
+    "  <div class=\"voicing-grid\">",
+    voicingRows,
+    "  </div>",
+    "</section>",
+  ].join("\n");
+
+  return htmlFrame(`${chord.root} ${chord.quality} | GCKB`, "../assets/site.css", body);
+}
+
+export function siteChordFileName(chordId: string): string {
+  return chordFileName(chordId);
+}

--- a/src/cli/build.ts
+++ b/src/cli/build.ts
@@ -5,6 +5,12 @@ import { coverageDashboardMarkdown } from "../build/docs/generateCoverage.js";
 import { chordDocFileName, voicingDiagramFileName } from "../build/docs/paths.js";
 import { buildDocsSitemap } from "../build/docs/generateSitemap.js";
 import { writeChordJsonl } from "../build/output/writeJsonl.js";
+import {
+  siteChordFileName,
+  siteChordHtml,
+  siteIndexHtml,
+  siteStylesheet,
+} from "../build/site/generateSite.js";
 import { generateChordSvg } from "../build/svg/generateSvg.js";
 import { ingestNormalizedChords } from "../ingest/pipeline.js";
 import { SOURCE_REGISTRY } from "../ingest/sourceRegistry.js";
@@ -103,12 +109,18 @@ async function main(): Promise<void> {
 
   await rm(path.join("docs", "chords"), { recursive: true, force: true });
   await rm(path.join("docs", "diagrams"), { recursive: true, force: true });
+  await rm("site", { recursive: true, force: true });
   await writeChordJsonl(path.join("data", "chords.jsonl"), chords);
   await mkdir(path.join("docs", "chords"), { recursive: true });
   await mkdir(path.join("docs", "diagrams"), { recursive: true });
+  await mkdir(path.join("site", "assets"), { recursive: true });
+  await mkdir(path.join("site", "chords"), { recursive: true });
+  await mkdir(path.join("site", "diagrams"), { recursive: true });
   await writeText(path.join("docs", "index.md"), chordIndexMarkdown(chords));
   const coverageReport = buildRootQualityCoverageReport(chords);
   await writeText(path.join("docs", "coverage.md"), coverageDashboardMarkdown(coverageReport));
+  await writeText(path.join("site", "index.html"), siteIndexHtml(chords));
+  await writeText(path.join("site", "assets", "site.css"), siteStylesheet());
 
   const sitemapGeneratedAt =
     process.env.DOCS_SITEMAP_GENERATED_AT ??
@@ -122,10 +134,19 @@ async function main(): Promise<void> {
       path.join("docs", "chords", chordDocFileName(chord.id)),
       chordMarkdown(chord, chords),
     );
+    await writeText(
+      path.join("site", "chords", siteChordFileName(chord.id)),
+      siteChordHtml(chord, chords),
+    );
     for (const voicing of chord.voicings) {
       const svg = generateChordSvg(voicing, chord.tuning);
+      const diagramName = voicingDiagramFileName(voicing.id);
       await writeText(
-        path.join("docs", "diagrams", voicingDiagramFileName(voicing.id)),
+        path.join("docs", "diagrams", diagramName),
+        svg,
+      );
+      await writeText(
+        path.join("site", "diagrams", diagramName),
         svg,
       );
     }

--- a/test/unit/docs.test.ts
+++ b/test/unit/docs.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { chordIndexMarkdown, chordMarkdown } from "../../src/build/docs/generateDocs.js";
 import { coverageDashboardMarkdown } from "../../src/build/docs/generateCoverage.js";
+import { siteChordFileName, siteChordHtml, siteIndexHtml } from "../../src/build/site/generateSite.js";
 import { buildRootQualityCoverageReport } from "../../src/validate/coverage.js";
 import type { ChordRecord } from "../../src/types/model.js";
 
@@ -49,6 +50,16 @@ function extractMarkdownLinks(markdown: string): string[] {
     .map((match) => {
       const capture = /\[[^\]]+\]\(([^)]+)\)/.exec(match);
       return capture?.[1];
+    })
+    .filter((value): value is string => Boolean(value));
+}
+
+function extractHtmlLinks(html: string): string[] {
+  const links = html.match(/(?:href|src)="([^"]+)"/g) ?? [];
+  return links
+    .map((entry) => {
+      const match = /(?:href|src)="([^"]+)"/.exec(entry);
+      return match?.[1];
     })
     .filter((value): value is string => Boolean(value));
 }
@@ -363,5 +374,90 @@ describe("coverageDashboardMarkdown", () => {
     const report = buildRootQualityCoverageReport([], { roots: ["C"], qualities: ["maj", "min", "7"] });
     const md = coverageDashboardMarkdown(report, { missingLimit: 2 });
     expect(md).toContain("_Showing first 2 of 3 missing IDs (deterministic order)._");
+  });
+});
+
+describe("site generation", () => {
+  it("renders a deterministic site index with root and quality navigation", () => {
+    const chords = [
+      buildChord({ id: "chord:C:min", root: "C", quality: "min", aliases: ["Cm"] }),
+      buildChord({ id: "chord:C:maj", root: "C", quality: "maj", aliases: ["C"] }),
+      buildChord({ id: "chord:Db:maj", root: "Db", quality: "maj", aliases: ["Db"] }),
+    ];
+
+    const html = siteIndexHtml(chords);
+    const reversed = siteIndexHtml([...chords].reverse());
+
+    expect(html).toBe(reversed);
+    expect(html).toContain("Guitar Chord Knowledge Base");
+    expect(html).toContain("href=\"#root-c\"");
+    expect(html).toContain("href=\"#root-db\"");
+    expect(html).toContain("href=\"./chords/chord__C__maj.html\"");
+    expect(html).toContain("href=\"./chords/chord__C__min.html\"");
+    expect(html).toContain("href=\"./chords/chord__Db__maj.html\"");
+  });
+
+  it("renders chord pages with voicing diagrams, provenance, and cross-links", () => {
+    const cSharp = buildChord({
+      id: "chord:C#:maj",
+      root: "C#",
+      quality: "maj",
+      enharmonic_equivalents: ["chord:Db:maj"],
+      source_refs: [{ source: "guitar-chord-org", url: "https://example.com/c-sharp-major" }],
+    });
+    const dFlat = buildChord({
+      id: "chord:Db:maj",
+      root: "Db",
+      quality: "maj",
+      enharmonic_equivalents: [],
+      source_refs: [{ source: "all-guitar-chords", url: "https://example.com/d-flat-major" }],
+    });
+    const cMin = buildChord({
+      id: "chord:C#:min",
+      root: "C#",
+      quality: "min",
+      enharmonic_equivalents: [],
+    });
+
+    const html = siteChordHtml(cSharp, [cSharp, dFlat, cMin]);
+
+    expect(html).toContain("src=\"../diagrams/chord__C__maj__v1.svg\"");
+    expect(html).toContain("href=\"./chord__Db__maj.html\"");
+    expect(html).toContain("href=\"./chord__C%23__min.html\"");
+    expect(html).toContain("href=\"https://example.com/c-sharp-major\"");
+    expect(html).toContain("Back to index");
+  });
+
+  it("emits only resolvable internal links across generated index/chord pages", () => {
+    const chords = [
+      buildChord({ id: "chord:C:maj", root: "C", quality: "maj", enharmonic_equivalents: ["chord:Db:maj"] }),
+      buildChord({ id: "chord:C:min", root: "C", quality: "min", enharmonic_equivalents: [] }),
+      buildChord({ id: "chord:Db:maj", root: "Db", quality: "maj", enharmonic_equivalents: [] }),
+    ];
+
+    const index = siteIndexHtml(chords);
+    const pages = new Map<string, string>([
+      ["./index.html", index],
+      ...chords.map((chord) => [`./chords/${siteChordFileName(chord.id)}`, siteChordHtml(chord, chords)] as const),
+    ]);
+
+    const internalTargets = new Set<string>([
+      "./index.html",
+      "./assets/site.css",
+      ...chords.map((chord) => `./chords/${siteChordFileName(chord.id)}`),
+      ...chords.flatMap((chord) => chord.voicings.map((voicing) => `./diagrams/${voicing.id.replace(/:/g, "__").replace(/#/g, "%23")}.svg`)),
+    ]);
+
+    for (const [pathName, html] of pages.entries()) {
+      for (const target of extractHtmlLinks(html)) {
+        if (target.startsWith("https://") || target.startsWith("http://") || target.startsWith("#")) {
+          continue;
+        }
+        const normalized = pathName === "./index.html"
+          ? target
+          : (target.startsWith("../") ? `./${target.slice(3)}` : `./chords/${target.slice(2)}`);
+        expect(internalTargets.has(normalized), `${pathName} -> ${target}`).toBe(true);
+      }
+    }
   });
 });


### PR DESCRIPTION
## Summary
- generate a deterministic static website output under `site/` during `npm run build`
- add responsive index/chord HTML generation with root-quality navigation, voicing diagrams, provenance, and enharmonic/related cross-links
- update README with local site preview instructions and add unit tests for site generation/link integrity

Closes #203

## Validation
- npm test -- test/unit/docs.test.ts test/unit/links.test.ts
- npm run build
- npm run check-links
- npm run lint