### PR TITLE
feat: cache completeness manifest and deploy ingest policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,12 +74,25 @@ jobs:
           exit $code
         continue-on-error: true
 
-      - name: ingest
+      - name: ingest policy
         id: ingest
         if: steps.install.outcome == 'success'
         run: |
           set +e
-          npm run ingest
+          npm run audit-cache
+          cache_code=$?
+          if [ "$cache_code" -ne 0 ]; then
+            echo "::error::Cache completeness policy failed; ingest/build is blocked until cache gaps are fixed."
+            echo "exit_code=$cache_code" >> "$GITHUB_OUTPUT"
+            exit $cache_code
+          fi
+          if [ -f data/generated/chords.normalized.json ]; then
+            echo "Ingest policy: cache completeness passed and normalized artifacts exist; skipping ingest."
+            echo "exit_code=0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Ingest policy: cache completeness passed but normalized artifacts are missing; running full ingest."
+          npm run ingest -- --mode full
           code=$?
           echo "exit_code=$code" >> "$GITHUB_OUTPUT"
           exit $code
@@ -208,7 +221,7 @@ jobs:
             echo "| lint     | \`npm run lint\` | $(icon "$STATUS_LINT") $STATUS_LINT | $EXIT_LINT |"
             echo "| test     | \`npm test\` | $(icon "$STATUS_TEST") $STATUS_TEST | $EXIT_TEST |"
             echo "| flaky-summary | \`npm run ci:flaky-summary\` | $(icon "$STATUS_FLAKY_SUMMARY") $STATUS_FLAKY_SUMMARY | $EXIT_FLAKY_SUMMARY |"
-            echo "| ingest   | \`npm run ingest\` | $(icon "$STATUS_INGEST") $STATUS_INGEST | $EXIT_INGEST |"
+            echo "| ingest-policy   | \`npm run audit-cache && (skip ingest OR npm run ingest -- --mode full)\` | $(icon "$STATUS_INGEST") $STATUS_INGEST | $EXIT_INGEST |"
             echo "| build    | \`npm run build\` | $(icon "$STATUS_BUILD") $STATUS_BUILD | $EXIT_BUILD |"
             echo "| docs-changelog | \`npm run docs-changelog\` | $(icon "$STATUS_DOCS_CHANGELOG") $STATUS_DOCS_CHANGELOG | $EXIT_DOCS_CHANGELOG |"
             echo "| cache-audit | \`npm run audit-cache\` | $(icon "$STATUS_CACHE_AUDIT") $STATUS_CACHE_AUDIT | $EXIT_CACHE_AUDIT |"
@@ -229,7 +242,7 @@ jobs:
               [ "$STATUS_LINT"     = "failure" ] && echo "- **lint failed**: run \`npm run lint\` locally and fix TypeScript errors."
               [ "$STATUS_TEST"     = "failure" ] && echo "- **test failed**: run \`npm test\` locally; check for regressions in parsers, normalization, or SVG output."
               [ "$STATUS_FLAKY_SUMMARY" = "failure" ] && echo "- **flaky-summary failed**: run \`npm run ci:flaky-summary -- --input .artifacts/vitest-results.json\` and verify vitest JSON is present."
-              [ "$STATUS_INGEST"   = "failure" ] && echo "- **ingest failed**: run \`npm run ingest\` locally; verify cached HTML under \`data/sources/\` is present (\`npm run audit-cache\`)."
+              [ "$STATUS_INGEST"   = "failure" ] && echo "- **ingest policy failed**: run \`npm run audit-cache\` locally; fix missing/corrupt cache entries or run \`npm run ingest:full-refresh\`."
               [ "$STATUS_BUILD"    = "failure" ] && echo "- **build failed**: run \`npm run build\` locally; check docs/SVG generator errors."
               [ "$STATUS_DOCS_CHANGELOG" = "failure" ] && echo "- **docs-changelog failed**: run \`npm run docs-changelog\` locally and verify docs outputs exist after \`npm run build\`."
               [ "$STATUS_CACHE_AUDIT" = "failure" ] && echo "- **cache-audit failed**: run \`npm run audit-cache\` locally and restore missing/corrupt entries under \`data/sources/\`."

--- a/README.md
+++ b/README.md
@@ -182,6 +182,11 @@ Build behavior:
 
 - loads `data/generated/chords.normalized.json` if present
 - otherwise generates normalized records via ingest pipeline
+- in full build mode (no `--chord`/`--source` filters), enforces cache completeness
+  policy before build/deploy:
+  - writes `data/generated/cache-completeness.manifest.json`
+  - skips ingest when cache is complete and normalized artifacts already exist
+  - fails fast with missing/corrupt cache target details when completeness fails
 - sorts records deterministically
 - validates records
 - regenerates JSONL/docs/SVG/static-site artifacts
@@ -304,8 +309,18 @@ fast on the first error. `build` includes the ingest pipeline if
 To include a full source refresh before the gate:
 
 ```bash
-npm run ingest && npm run preflight
+npm run ingest:full-refresh && npm run preflight
 ```
+
+Routine deploy-friendly flow:
+
+```bash
+npm run audit-cache
+npm run preflight
+```
+
+`npm run audit-cache` writes a deterministic cache completeness report to
+`data/generated/cache-completeness.manifest.json`.
 
 ## Typical local workflows
 
@@ -318,7 +333,7 @@ npm run preflight
 For a full source refresh first:
 
 ```bash
-npm run ingest && npm run preflight
+npm run ingest:full-refresh && npm run preflight
 ```
 
 ### Fast artifact refresh during development

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "ingest": "tsx src/cli/ingest.ts",
+    "ingest:full-refresh": "tsx src/cli/ingest.ts --mode full --refresh",
     "build": "tsx src/cli/build.ts",
     "validate": "tsx src/cli/validate.ts",
     "ci:flaky-summary": "tsx src/ci/flakySummary.ts",

--- a/src/cli/auditCache.ts
+++ b/src/cli/auditCache.ts
@@ -1,4 +1,7 @@
-import { auditCache } from "../ingest/cacheAudit.js";
+import path from "node:path";
+import { mkdir } from "node:fs/promises";
+import { auditCache, buildCacheCompletenessManifest } from "../ingest/cacheAudit.js";
+import { writeJson } from "../utils/fs.js";
 
 function formatLine(source: string, slug: string, status: string, checksum?: string): string {
   const tag = status.toUpperCase().padEnd(8);
@@ -8,6 +11,7 @@ function formatLine(source: string, slug: string, status: string, checksum?: str
 
 async function main(): Promise<void> {
   const result = await auditCache();
+  const manifest = buildCacheCompletenessManifest(result);
 
   for (const entry of result.entries) {
     process.stdout.write(
@@ -18,6 +22,10 @@ async function main(): Promise<void> {
   process.stdout.write(
     `\nSummary: ${result.okCount} ok, ${result.missingCount} missing, ${result.corruptCount} corrupt (${result.totalExpected} expected)\n`,
   );
+  await mkdir(path.join("data", "generated"), { recursive: true });
+  const manifestPath = path.join("data", "generated", "cache-completeness.manifest.json");
+  await writeJson(manifestPath, manifest);
+  process.stdout.write(`Manifest: ${manifestPath}\n`);
 
   if (result.missingCount > 0 || result.corruptCount > 0) {
     process.stderr.write(

--- a/src/cli/build.ts
+++ b/src/cli/build.ts
@@ -17,6 +17,7 @@ import {
 import { generateChordSvg } from "../build/svg/generateSvg.js";
 import { ingestNormalizedChords } from "../ingest/pipeline.js";
 import { SOURCE_REGISTRY } from "../ingest/sourceRegistry.js";
+import { auditCache, buildCacheCompletenessManifest } from "../ingest/cacheAudit.js";
 import type { ChordRecord } from "../types/model.js";
 import { sharpAliasForFlatCanonicalRoot, toFlatCanonicalRoot } from "../types/guards.js";
 import { compareChordOrder } from "../utils/sort.js";
@@ -28,6 +29,7 @@ import { FULL_MATRIX_TARGETS } from "../config.js";
 
 const NORMALIZED_PATH = path.join("data", "generated", "chords.normalized.json");
 const DEFAULT_SITEMAP_GENERATED_AT = "1970-01-01T00:00:00.000Z";
+const CACHE_MANIFEST_PATH = path.join("data", "generated", "cache-completeness.manifest.json");
 
 interface BuildRuntimeOptions {
   chord?: string;
@@ -38,6 +40,27 @@ interface BuildRuntimeOptions {
 async function loadNormalized(): Promise<ChordRecord[]> {
   const content = await readFile(NORMALIZED_PATH, "utf8");
   return JSON.parse(content) as ChordRecord[];
+}
+
+export function shouldEnforceCacheCompletenessPolicy(options: BuildRuntimeOptions): boolean {
+  return !options.chord && !options.source;
+}
+
+export function cacheFailureMessage(
+  missing: ReadonlyArray<{ source: string; slug: string }>,
+  corrupt: ReadonlyArray<{ source: string; slug: string }>,
+): string {
+  const sample = [
+    ...missing.slice(0, 3).map((entry) => `${entry.source}/${entry.slug}.html (missing)`),
+    ...corrupt.slice(0, 3).map((entry) => `${entry.source}/${entry.slug}.html (corrupt)`),
+  ];
+
+  return [
+    "Cache completeness policy failed for full build/deploy mode.",
+    `Missing=${missing.length} Corrupt=${corrupt.length}`,
+    sample.length > 0 ? `Sample gaps: ${sample.join(", ")}` : "",
+    "Run `npm run ingest:full-refresh` and then retry `npm run preflight`.",
+  ].filter((line) => line.length > 0).join(" ");
 }
 
 export function filterBuildChords(chords: ChordRecord[], options: BuildRuntimeOptions): ChordRecord[] {
@@ -81,7 +104,20 @@ export function filterBuildChords(chords: ChordRecord[], options: BuildRuntimeOp
 }
 
 async function loadOrGenerateNormalized(options: BuildRuntimeOptions): Promise<ChordRecord[]> {
+  if (shouldEnforceCacheCompletenessPolicy(options)) {
+    const cacheAudit = await auditCache();
+    const cacheManifest = buildCacheCompletenessManifest(cacheAudit);
+    await writeJson(CACHE_MANIFEST_PATH, cacheManifest);
+
+    if (!cacheManifest.is_complete) {
+      throw new Error(cacheFailureMessage(cacheManifest.missing, cacheManifest.corrupt));
+    }
+  }
+
   if (await pathExists(NORMALIZED_PATH)) {
+    if (shouldEnforceCacheCompletenessPolicy(options)) {
+      process.stdout.write("Ingest policy: cache + normalized artifacts complete; skipping ingest.\n");
+    }
     const normalized = await loadNormalized();
     return filterBuildChords(normalized, options);
   }

--- a/src/cli/build.ts
+++ b/src/cli/build.ts
@@ -107,7 +107,9 @@ async function loadOrGenerateNormalized(options: BuildRuntimeOptions): Promise<C
   if (shouldEnforceCacheCompletenessPolicy(options)) {
     const cacheAudit = await auditCache();
     const cacheManifest = buildCacheCompletenessManifest(cacheAudit);
-    await writeJson(CACHE_MANIFEST_PATH, cacheManifest);
+    if (!options.dryRun) {
+      await writeJson(CACHE_MANIFEST_PATH, cacheManifest);
+    }
 
     if (!cacheManifest.is_complete) {
       throw new Error(cacheFailureMessage(cacheManifest.missing, cacheManifest.corrupt));

--- a/src/ingest/cacheAudit.ts
+++ b/src/ingest/cacheAudit.ts
@@ -24,7 +24,20 @@ export interface CacheAuditResult {
   corruptCount: number;
 }
 
+export interface CacheCompletenessManifest {
+  manifest_version: "cache-completeness/v1";
+  generated_at: string;
+  total_expected: number;
+  ok_count: number;
+  missing_count: number;
+  corrupt_count: number;
+  is_complete: boolean;
+  missing: ReadonlyArray<{ source: string; slug: string }>;
+  corrupt: ReadonlyArray<{ source: string; slug: string; checksum?: string }>;
+}
+
 const MINIMUM_VALID_HTML_BYTES = 64;
+const DEFAULT_MANIFEST_GENERATED_AT = "1970-01-01T00:00:00.000Z";
 
 function computeChecksum(content: Buffer): string {
   return createHash("sha256").update(content).digest("hex");
@@ -75,5 +88,26 @@ export async function auditCache(cacheBase = "data/sources"): Promise<CacheAudit
     okCount,
     missingCount,
     corruptCount,
+  };
+}
+
+export function buildCacheCompletenessManifest(
+  result: CacheAuditResult,
+  generatedAt = process.env.CACHE_MANIFEST_GENERATED_AT ?? DEFAULT_MANIFEST_GENERATED_AT,
+): CacheCompletenessManifest {
+  return {
+    manifest_version: "cache-completeness/v1",
+    generated_at: generatedAt,
+    total_expected: result.totalExpected,
+    ok_count: result.okCount,
+    missing_count: result.missingCount,
+    corrupt_count: result.corruptCount,
+    is_complete: result.missingCount === 0 && result.corruptCount === 0,
+    missing: result.entries
+      .filter((entry) => entry.status === "missing")
+      .map((entry) => ({ source: entry.source, slug: entry.slug })),
+    corrupt: result.entries
+      .filter((entry) => entry.status === "corrupt")
+      .map((entry) => ({ source: entry.source, slug: entry.slug, checksum: entry.checksum })),
   };
 }

--- a/src/ingest/cacheTargets.ts
+++ b/src/ingest/cacheTargets.ts
@@ -1,8 +1,14 @@
-import { CORE_MATRIX_TARGETS } from "../config.js";
+import { FULL_MATRIX_TARGETS } from "../config.js";
+import { SOURCE_REGISTRY } from "./sourceRegistry.js";
 
 export interface CacheTargetKey {
   source: string;
   slug: string;
+}
+
+interface SourceCapabilities {
+  roots: ReadonlySet<string>;
+  qualities: ReadonlySet<string>;
 }
 
 const SHARP_ALIAS_BY_FLAT_ROOT: Readonly<Record<string, string>> = {
@@ -63,10 +69,25 @@ function buildAliasSlug(chordId?: string): string | null {
 
 /** Build sorted list of unique (source, slug) pairs expected in cache. */
 export function expectedCacheKeys(): CacheTargetKey[] {
+  const capabilitiesBySource = new Map<string, SourceCapabilities>(
+    SOURCE_REGISTRY.map((entry) => [entry.id, {
+      roots: new Set(entry.capabilities.roots),
+      qualities: new Set(entry.capabilities.qualities),
+    }]),
+  );
   const seen = new Set<string>();
   const keys: CacheTargetKey[] = [];
 
-  for (const target of CORE_MATRIX_TARGETS) {
+  for (const target of FULL_MATRIX_TARGETS) {
+    const sourceCapabilities = capabilitiesBySource.get(target.source);
+    const parsed = parseChordId(target.chordId);
+    if (!sourceCapabilities || !parsed) {
+      continue;
+    }
+    if (!sourceCapabilities.roots.has(parsed.root) || !sourceCapabilities.qualities.has(parsed.quality)) {
+      continue;
+    }
+
     const slugs = [target.slug];
     const aliasSlug = buildAliasSlug(target.chordId);
     if (aliasSlug) {

--- a/test/unit/buildCli.test.ts
+++ b/test/unit/buildCli.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { filterBuildChords } from "../../src/cli/build.js";
+import { cacheFailureMessage, filterBuildChords, shouldEnforceCacheCompletenessPolicy } from "../../src/cli/build.js";
 import type { ChordRecord } from "../../src/types/model.js";
 
 function chord(overrides: Partial<ChordRecord>): ChordRecord {
@@ -44,5 +44,27 @@ describe("filterBuildChords", () => {
 
     expect(() => filterBuildChords(chords, { source: "guitarr-chord-org", chord: undefined, dryRun: false }))
       .toThrow("Unknown source: guitarr-chord-org");
+  });
+
+  it("enforces cache completeness policy only for full build mode", () => {
+    expect(shouldEnforceCacheCompletenessPolicy({ dryRun: false })).toBe(true);
+    expect(shouldEnforceCacheCompletenessPolicy({ dryRun: false, chord: "chord:C:maj" })).toBe(false);
+    expect(shouldEnforceCacheCompletenessPolicy({ dryRun: false, source: "guitar-chord-org" })).toBe(false);
+  });
+
+  it("formats deterministic cache policy failure messages with remediation guidance", () => {
+    const message = cacheFailureMessage(
+      [
+        { source: "all-guitar-chords", slug: "c-major" },
+        { source: "guitar-chord-org", slug: "d-major" },
+      ],
+      [{ source: "all-guitar-chords", slug: "e-major" }],
+    );
+
+    expect(message).toContain("Cache completeness policy failed");
+    expect(message).toContain("Missing=2 Corrupt=1");
+    expect(message).toContain("all-guitar-chords/c-major.html (missing)");
+    expect(message).toContain("all-guitar-chords/e-major.html (corrupt)");
+    expect(message).toContain("npm run ingest:full-refresh");
   });
 });

--- a/test/unit/cacheAudit.test.ts
+++ b/test/unit/cacheAudit.test.ts
@@ -15,6 +15,7 @@ vi.mock("../../src/config.js", async (importOriginal) => {
   ] as const;
   return {
     ...actual,
+    FULL_MATRIX_TARGETS: targets,
     CORE_MATRIX_TARGETS: targets,
     MVP_TARGETS: targets,
   };
@@ -122,5 +123,27 @@ describe("auditCache", () => {
     expect(result.okCount).toBe(1);
     expect(result.corruptCount).toBe(1);
     expect(result.missingCount).toBe(1);
+  });
+
+  it("builds a deterministic cache completeness manifest snapshot", async () => {
+    const { buildCacheCompletenessManifest } = await import("../../src/ingest/cacheAudit.js");
+    const result = await auditCache(path.join(tempDir, "data", "sources"));
+    const manifest = buildCacheCompletenessManifest(result, "2026-03-01T00:00:00.000Z");
+
+    expect(manifest).toEqual({
+      manifest_version: "cache-completeness/v1",
+      generated_at: "2026-03-01T00:00:00.000Z",
+      total_expected: 3,
+      ok_count: 0,
+      missing_count: 3,
+      corrupt_count: 0,
+      is_complete: false,
+      missing: [
+        { source: "all-guitar-chords", slug: "c-major" },
+        { source: "guitar-chord-org", slug: "c-major" },
+        { source: "guitar-chord-org", slug: "c-minor" },
+      ],
+      corrupt: [],
+    });
   });
 });

--- a/test/unit/cacheTargets.test.ts
+++ b/test/unit/cacheTargets.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/config.js")>();
+  return {
+    ...actual,
+    FULL_MATRIX_TARGETS: [
+      {
+        source: "all-guitar-chords",
+        chordId: "chord:Db:maj",
+        slug: "d-flat-major",
+        url: "https://example.test/all/db-major",
+      },
+      {
+        source: "all-guitar-chords",
+        chordId: "chord:Db:dim7",
+        slug: "d-flat-dim7",
+        url: "https://example.test/all/db-dim7",
+      },
+      {
+        source: "guitar-chord-org",
+        chordId: "chord:C:maj",
+        slug: "c-major",
+        url: "https://example.test/gco/c-major",
+      },
+      {
+        source: "guitar-chord-org",
+        chordId: "chord:Db:maj",
+        slug: "d-flat-major",
+        url: "https://example.test/gco/db-major",
+      },
+    ],
+  };
+});
+
+vi.mock("../../src/ingest/sourceRegistry.js", () => ({
+  SOURCE_REGISTRY: [
+    {
+      id: "all-guitar-chords",
+      capabilities: {
+        roots: ["Db"],
+        qualities: ["maj"],
+      },
+    },
+    {
+      id: "guitar-chord-org",
+      capabilities: {
+        roots: ["C", "Db"],
+        qualities: ["maj"],
+      },
+    },
+  ],
+}));
+
+describe("expectedCacheKeys", () => {
+  it("uses capability-filtered full-matrix targets and includes deterministic sharp aliases", async () => {
+    const { expectedCacheKeys } = await import("../../src/ingest/cacheTargets.js");
+
+    expect(expectedCacheKeys()).toEqual([
+      { source: "all-guitar-chords", slug: "c-sharp-major" },
+      { source: "all-guitar-chords", slug: "d-flat-major" },
+      { source: "guitar-chord-org", slug: "c-major" },
+      { source: "guitar-chord-org", slug: "c-sharp-major" },
+      { source: "guitar-chord-org", slug: "d-flat-major" },
+    ]);
+  });
+});

--- a/test/unit/freshnessReport.test.ts
+++ b/test/unit/freshnessReport.test.ts
@@ -18,6 +18,7 @@ vi.mock("../../src/config.js", async (importOriginal) => {
   ] as const;
   return {
     ...actual,
+    FULL_MATRIX_TARGETS: targets,
     CORE_MATRIX_TARGETS: targets,
     MVP_TARGETS: targets,
   };


### PR DESCRIPTION
## Summary
- add deterministic cache completeness manifest generation (`cache-completeness/v1`) in `audit-cache`
- shift expected cache target computation to capability-filtered full-matrix targets, including sharp alias cache keys
- enforce full-build ingest policy in `build`: skip ingest when cache+normalized artifacts are complete, fail fast on missing/corrupt cache coverage with actionable guidance
- add explicit full-refresh command path via `npm run ingest:full-refresh`
- update CI ingest step to follow cache completeness policy and update README workflow guidance
- add/expand tests for cache target derivation, manifest shape, freshness mocks, and build policy helpers

Closes #230

## Validation
- npm run audit-cache
- npm run preflight
- npm test -- test/unit/cacheTargets.test.ts test/unit/cacheAudit.test.ts test/unit/buildCli.test.ts test/unit/freshnessReport.test.ts
- npm run build -- --dry-run

## Notes
- `preflight` now exercises the full-build cache completeness policy through `npm run build`.