### PR TITLE
docs: remove stale MVP framing and align governance wording

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@ Every chord and voicing must keep `source_refs` with:
 - Canonical chord IDs follow `chord:<ROOT>:<QUALITY>`.
 - Canonical root policy and enharmonic behavior must follow ADRs.
 - Keep machine outputs schema-valid (`chords.schema.json`) at all times.
-- Use the term `voicing` in active internal guidance (not `variation`).
+- Use the term `voicing` consistently in active internal guidance.
 
 ### 3.3 Separation of concerns
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ GCKB is a deterministic pipeline that transforms cached chord source pages into:
 - Human-facing Markdown pages with generated chord diagrams
 - LLM-friendly normalized JSONL with stable canonical IDs and provenance
 
-Primary scope (MVP): chord references (C, Cm, C7, Cmaj7) from two sources.
+Current scope: deterministic chord-reference coverage from two sources across
+the configured root/quality matrix.
 
 ## What this repository does
 
@@ -420,7 +421,7 @@ Website publishing workflow:
 
 ## Project status
 
-MVP scope is implemented; current focus is post-MVP hardening:
+Current focus is production hardening:
 
 - documentation clarity
 - stronger determinism/provenance regression guards

--- a/docs/contributing/adding-a-source.md
+++ b/docs/contributing/adding-a-source.md
@@ -29,23 +29,19 @@ into the GCKB ingest pipeline.
 - [ ] Pick a short, lowercase, hyphenated identifier, e.g. `my-chord-source`.
 - [ ] The ID must be unique across `SOURCE_REGISTRY` in
   [`src/ingest/sourceRegistry.ts`](../../src/ingest/sourceRegistry.ts).
-- [ ] Add the new ID to the `IngestTarget["source"]` union in
-  [`src/config.ts`](../../src/config.ts).
+- [ ] Add the new ID to `SOURCE_PRIORITY` in
+  [`src/config.ts`](../../src/config.ts) so it becomes part of `SourceId`.
 
 ### 2. Add the source targets to `config.ts`
 
 In [`src/config.ts`](../../src/config.ts):
 
-- [ ] Add entries to `MVP_TARGETS` (or a parallel targets array) for each
-  chord / root combination you want to ingest.  Each entry must include:
-  ```ts
-  {
-    source: "<your-source-id>",
-    chordId: "chord:<ROOT>:<QUALITY>",  // e.g. "chord:C:maj"
-    slug:    "<root>-<quality>",         // used as the cache filename
-    url:     "https://...",              // exact page URL to fetch
-  }
-  ```
+- [ ] Add a `case` for the new source in `buildTargetForSource(...)`.
+- [ ] Define deterministic slug and URL construction for every root/quality pair.
+- [ ] Confirm the source appears in `FULL_MATRIX_TARGETS` with canonical
+  `chordId` values (`chord:<ROOT>:<QUALITY>`).
+- [ ] If source precedence needs to change, update `SOURCE_PRIORITY` ordering
+  intentionally and document why in the PR.
 
 ### 3. Cache the source HTML
 
@@ -189,8 +185,8 @@ All four commands must pass with no errors before opening a PR.
 
 | # | Step | File(s) affected |
 |---|------|-----------------|
-| 1 | Choose source ID, add to `IngestTarget["source"]` union | `src/config.ts` |
-| 2 | Add ingest targets to `MVP_TARGETS` | `src/config.ts` |
+| 1 | Choose source ID, add to `SOURCE_PRIORITY` (`SourceId`) | `src/config.ts` |
+| 2 | Add source case to deterministic target builder | `src/config.ts` |
 | 3 | Cache HTML via `npm run ingest --refresh` | `data/sources/<id>/` |
 | 4 | Write parser returning `RawChordRecord` with provenance | `src/ingest/parsers/<id>.ts` |
 | 5 | Register in `SOURCE_REGISTRY` | `src/ingest/sourceRegistry.ts` |

--- a/planning/prompts/autonomous-maintenance.md
+++ b/planning/prompts/autonomous-maintenance.md
@@ -3,6 +3,10 @@
 Use this prompt to instruct an agent to run continuous, unsupervised
 maintenance cycles on this repository.
 
+Policy alignment:
+- This prompt defines operational workflow.
+- `AGENTS.md` remains authoritative for legal/provenance constraints.
+
 ---
 
 ```

--- a/planning/prompts/planning-stage-issue-seeding.md
+++ b/planning/prompts/planning-stage-issue-seeding.md
@@ -3,10 +3,14 @@
 Use this prompt to generate the next roadmap wave (one parent planning issue plus 10–20 child execution issues) with consistent triage.
 
 > **Revision history**
-> - v1 — initial seeding wave (MVP foundation)
+> - v1 — initial seeding wave foundation
 > - v2 (current) — lessons from P0/P1 completion wave; adds label policy,
 >   dependency notation, execution ordering, `status/blocked` handling, and
 >   Copilot review integration guidance
+
+Policy alignment:
+- This prompt is procedural guidance.
+- `AGENTS.md` remains the authoritative source for legal/provenance policy.
 
 ---
 


### PR DESCRIPTION
## Summary
- remove stale MVP framing from active contributor-facing docs
- keep voicing terminology consistent across AGENTS, README, prompts, and contributor docs
- update adding-a-source guidance to reflect current config model (SOURCE_PRIORITY + deterministic target builder)
- add explicit prompt-to-AGENTS alignment notes so legal/provenance policy precedence is unambiguous

Closes #232

## Validation
- npm run lint
- npm test
- npm run build && npm run validate
- rg -n "\bMVP\b|variation" AGENTS.md README.md planning/prompts docs/contributing
